### PR TITLE
Return missing membership data for memberbooth

### DIFF
--- a/api/src/multiaccess/views.py
+++ b/api/src/multiaccess/views.py
@@ -46,7 +46,8 @@ def memberbooth_response_object(member, membership_data):
 
 @service.route("/memberbooth/tag", method=GET, permission=MEMBERBOOTH)
 def memberbooth_tag(tagid=Arg(int)):
-    key = db_session.query(Key).join(Key.member) \
+    key = db_session.query(Key)\
+        .join(Key.member) \
         .filter(Key.tagid == tagid) \
         .filter(
             Member.deleted_at.is_(None),
@@ -65,7 +66,7 @@ def memberbooth_tag(tagid=Arg(int)):
 def memberbooth_member(member_number=Arg(int)):
     member = db_session.query(Member).filter(Member.member_number == member_number, Member.deleted_at.is_(None)).first()
 
-    if member is None:
+    if not member:
         return None
 
     membership_data = get_membership_summary(member.member_id)

--- a/api/src/multiaccess/views.py
+++ b/api/src/multiaccess/views.py
@@ -2,6 +2,7 @@ from flask import g
 from sqlalchemy.orm import contains_eager
 
 from membership.models import Member, Span, Key
+from membership.membership import get_membership_summary
 from multiaccess import service
 from multiaccess.box_terminator import box_terminator_validate, box_terminator_nag, \
     box_terminator_boxes
@@ -36,21 +37,17 @@ def get_memberdata():
     return [member_to_response_object(m) for m in query]
 
 
-def memberbooth_response_object(member, key):
-    return {
-        'member_id': member.member_id,
-        'key_id': key.key_id if key else None,
-        'tagid': key.tagid if key else None,
-        'description': key.description if key else None,
-        'member': member_to_response_object(member)
-    }
+def memberbooth_response_object(member, membership_data):
+    response = member_to_response_object(member)
+    del response["end_date"]
+    response["membership_data"] = membership_data.as_json()
+    return response
 
 
 @service.route("/memberbooth/tag", method=GET, permission=MEMBERBOOTH)
-def get_keys(tagid=Arg(int)):
-    key = db_session.query(Key) \
+def memberbooth_tag(tagid=Arg(int)):
+    key = db_session.query(Key).join(Key.member) \
         .filter(Key.tagid == tagid) \
-        .join(Key.member) \
         .filter(
             Member.deleted_at.is_(None),
             Key.deleted_at.is_(None),
@@ -59,19 +56,20 @@ def get_keys(tagid=Arg(int)):
 
     if key is None:
         return None
-    else:
-        return memberbooth_response_object(key.member, key)
+
+    membership_data = get_membership_summary(key.member_id)
+    return memberbooth_response_object(key.member, membership_data)
 
 
 @service.route("/memberbooth/member", method=GET, permission=MEMBERBOOTH)
 def memberbooth_member(member_number=Arg(int)):
-    member = db_session.query(Member).filter(Member.member_number == member_number, Member.deleted_at.is_(None)).one()
-    key = db_session.query(Key).filter(Key.member_id == member.member_id, Key.deleted_at.is_(None)).first()
+    member = db_session.query(Member).filter(Member.member_number == member_number, Member.deleted_at.is_(None)).first()
 
-    if member:
-        return memberbooth_response_object(member, key)
+    if member is None:
+        return None
 
-    return None
+    membership_data = get_membership_summary(member.member_id)
+    return memberbooth_response_object(member, membership_data)
 
 
 @service.route("/box-terminator/boxes", method=GET, permission=MEMBER_EDIT)

--- a/api/src/systest/api/memberbooth_test.py
+++ b/api/src/systest/api/memberbooth_test.py
@@ -2,10 +2,10 @@ from test_aid.systest_base import ApiTest
 
 
 class Test(ApiTest):
-    
+
     def test_memberbooth_can_get_member_by_number_even_if_member_does_not_have_a_key(self):
         member = self.db.create_member()
-        
+
         self.api.get('/multiaccess/memberbooth/member', params=dict(member_number=member.member_number)).expect(
             200,
             data__keys=[],
@@ -16,8 +16,20 @@ class Test(ApiTest):
     def test_memberbooth_can_get_member_by_number(self):
         member = self.db.create_member()
         key = self.db.create_key()
-        
+
         response = self.api.get('/multiaccess/memberbooth/member', params=dict(member_number=member.member_number))
+        response.expect(
+            200,
+            data__firstname=member.firstname,
+            data__member_id=member.member_id,
+        )
+        self.assertNotEqual([], response.data["keys"], "There exists keys")
+
+    def test_memberbooth_can_get_member_by_tag(self):
+        member = self.db.create_member()
+        key = self.db.create_key()
+
+        response = self.api.get('/multiaccess/memberbooth/tag', params=dict(tagid=key.tagid))
         response.expect(
             200,
             data__firstname=member.firstname,

--- a/api/src/systest/api/memberbooth_test.py
+++ b/api/src/systest/api/memberbooth_test.py
@@ -3,13 +3,13 @@ from test_aid.systest_base import ApiTest
 
 class Test(ApiTest):
     
-    def test_memberbooth_can_get_member_by_number_even_if_memeber_does_not_have_a_key(self):
+    def test_memberbooth_can_get_member_by_number_even_if_member_does_not_have_a_key(self):
         member = self.db.create_member()
         
         self.api.get('/multiaccess/memberbooth/member', params=dict(member_number=member.member_number)).expect(
             200,
-            data__key_id=None,
-            data__member__firstname=member.firstname,
+            data__keys=[],
+            data__firstname=member.firstname,
             data__member_id=member.member_id,
         )
 
@@ -17,10 +17,10 @@ class Test(ApiTest):
         member = self.db.create_member()
         key = self.db.create_key()
         
-        self.api.get('/multiaccess/memberbooth/member', params=dict(member_number=member.member_number)).expect(
+        response = self.api.get('/multiaccess/memberbooth/member', params=dict(member_number=member.member_number))
+        response.expect(
             200,
-            data__key_id=key.key_id,
-            data__tagid=key.tagid,
-            data__member__firstname=member.firstname,
+            data__firstname=member.firstname,
             data__member_id=member.member_id,
         )
+        self.assertNotEqual([], response.data["keys"], "There exists keys")


### PR DESCRIPTION
Only the membership was returned before. Now also lab-membership, effective membership and special membership are returned (like for the frontend membership view).