### PR TITLE
Fix: Missing text on navigation items when on mobile

### DIFF
--- a/admin/src/nav.jsx
+++ b/admin/src/nav.jsx
@@ -11,7 +11,7 @@ const NavItem = withRouter(props => {
     return (
         <li>
             <NavLink activeClassName="uk-active" to={target}>
-                <i className={"uk-icon-" + icon} />&nbsp;<span className="uk-hidden-small">{text}</span>
+                <i className={"uk-icon-" + icon} />&nbsp;<span>{text}</span>
             </NavLink>
         </li>
     );
@@ -38,7 +38,7 @@ export const SideNav = withRouter(({ nav, location }) => {
     }
 
     return (
-        <div className="uk-panel uk-panel-box" data-uk-sticky="{top:35}">
+        <div className="uk-panel uk-panel-box" style={{ marginBottom: "1em" }} data-uk-sticky="{top:35}">
             <ul className="uk-nav uk-nav-side" data-uk-scrollspy-nav="{closest:'li', smoothscroll:true}">
                 <li className="uk-nav-header">{activeItem.text}</li>
                 <li className="uk-nav-divider" />


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/7572427/105762800-2efb1d80-5f55-11eb-9e28-3bb6bd66d77d.png)

## After
![image](https://user-images.githubusercontent.com/7572427/105762835-3e7a6680-5f55-11eb-855f-c90082a6ecd6.png)
