### PR TITLE
Better search experience

### DIFF
--- a/admin/src/Components/SearchBox.jsx
+++ b/admin/src/Components/SearchBox.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default class SearchBox extends React.Component {
+
+    render() {
+        return (
+            <div className="filterbox">
+                <div className="uk-grid">
+                    <div className="uk-width-2-3">
+                        <form className="uk-form" onSubmit={(e) => e.preventDefault()}>
+                            <div className="uk-form-icon">
+                                <i className="uk-icon-search"/>
+                                <input value={this.props.value} ref={c => this.search = c} tabIndex="1" type="text" className="uk-form-width-large" placeholder="Skriv in ett sökord" onChange={(e) => this.props.handleChange(e.target.value)} />
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/admin/src/Membership/GroupList.jsx
+++ b/admin/src/Membership/GroupList.jsx
@@ -3,31 +3,9 @@ import { Link } from 'react-router-dom';
 import Collection from "../Models/Collection";
 import CollectionTable from "../Components/CollectionTable";
 import Group from "../Models/Group";
+import SearchBox from "../Components/SearchBox";
 
-
-class SearchBox extends React.Component {
-    
-    constructor(props) {
-        super(props);
-    }
-    
-    render() {
-        return (
-            <div className="filterbox">
-                <div className="uk-grid">
-                    <form className="uk-form">
-                        <div className="uk-form-icon">
-                            <i className="uk-icon-search"/>
-                            <input ref={c => { this.search = c; }} tabIndex="1" type="text" className="uk-form-width-large" placeholder="Skriv in ett sökord"
-                                onChange={() => this.props.onChange(this.search.value)} />
-                        </div>
-                    </form>
-                </div>
-            </div>
-        );
-    }
-}
-
+const URL = "/membership/groups";
 
 const Row = props => {
     const {item, deleteItem} = props;
@@ -47,7 +25,18 @@ class GroupList extends React.Component {
 
     constructor(props) {
         super(props);
-        this.collection = new Collection({type: Group});
+        this.onSearch = this.onSearch.bind(this);
+
+        const params = new URLSearchParams(this.props.location.search);
+        const search_term = params.get('search') || '';
+        this.collection = new Collection({type: Group, search: search_term});
+        this.state = {'search': search_term};
+    }
+
+    onSearch(term) {
+        this.setState({'search': term});
+        this.collection.updateSearch(term);
+        this.props.history.replace(URL + "?search=" + term);
     }
 
     render() {
@@ -65,7 +54,7 @@ class GroupList extends React.Component {
                 <p className="uk-float-left">På denna sida ser du en lista på samtliga grupper..</p>
                 <Link to="/membership/groups/add" className="uk-button uk-button-primary uk-float-right"><i className="uk-icon-plus-circle"/> Skapa ny grupp</Link>
 
-                <SearchBox onChange={terms => this.collection.updateSearch(terms)} />
+                <SearchBox handleChange={this.onSearch} />
                 <CollectionTable rowComponent={Row} collection={this.collection} columns={columns} />
             </div>
         );

--- a/admin/src/Membership/GroupList.jsx
+++ b/admin/src/Membership/GroupList.jsx
@@ -5,8 +5,6 @@ import CollectionTable from "../Components/CollectionTable";
 import Group from "../Models/Group";
 import SearchBox from "../Components/SearchBox";
 
-const URL = "/membership/groups";
-
 const Row = props => {
     const {item, deleteItem} = props;
     
@@ -27,8 +25,8 @@ class GroupList extends React.Component {
         super(props);
         this.onSearch = this.onSearch.bind(this);
 
-        const params = new URLSearchParams(this.props.location.search);
-        const search_term = params.get('search') || '';
+        this.params = new URLSearchParams(this.props.location.search);
+        const search_term = this.params.get('search') || '';
         this.collection = new Collection({type: Group, search: search_term});
         this.state = {'search': search_term};
     }
@@ -36,8 +34,14 @@ class GroupList extends React.Component {
     onSearch(term) {
         this.setState({'search': term});
         this.collection.updateSearch(term);
-        this.props.history.replace(URL + "?search=" + term);
+        if (term === "") {
+            this.params.delete("search");
+        } else {
+            this.params.set("search", term);
+        }
+        this.props.history.replace(this.props.location.pathname + "?" + this.params.toString());
     }
+
 
     render() {
         const columns = [

--- a/admin/src/Membership/KeyList.jsx
+++ b/admin/src/Membership/KeyList.jsx
@@ -4,33 +4,9 @@ import Collection from "../Models/Collection";
 import Key from "../Models/Key";
 import CollectionTable from "../Components/CollectionTable";
 import DateTimeShow from "../Components/DateTimeShow";
+import SearchBox from "../Components/SearchBox";
 
-
-class SearchBox extends React.Component {
-    
-    constructor(props) {
-        super(props);
-    }
-    
-    render() {
-        return (
-            <div className="filterbox">
-                <div className="uk-grid">
-                    <div className="uk-width-2-3">
-                        <form className="uk-form">
-                            <div className="uk-form-icon">
-                                <i className="uk-icon-search"/>
-                                <input ref={c => { this.search = c;}} tabIndex="1" type="text" className="uk-form-width-large" placeholder="Skriv in ett sökord"
-                                       onChange={() => this.props.onChange(this.search.value)} />
-                            </div>
-                        </form>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-}
-
+const URL = "/membership/keys";
 
 const Row = props => {
     const {item} = props;
@@ -49,7 +25,18 @@ class KeyList extends React.Component {
 
     constructor(props) {
         super(props);
-        this.collection = new Collection({type: Key, expand: "member"});
+        this.onSearch = this.onSearch.bind(this);
+
+        const params = new URLSearchParams(this.props.location.search);
+        const search_term = params.get('search') || '';
+        this.collection = new Collection({type: Key, expand: "member", search: search_term});
+        this.state = {'search': search_term};
+    }
+
+    onSearch(term) {
+        this.setState({'search': term});
+        this.collection.updateSearch(term);
+        this.props.history.replace(URL + "?search=" + term);
     }
 
     render() {
@@ -63,7 +50,7 @@ class KeyList extends React.Component {
         return (
             <div>
                 <h2>Nycklar</h2>
-                <SearchBox onChange={terms => this.collection.updateSearch(terms)} />
+                <SearchBox handleChange={this.onSearch} />
                 <CollectionTable rowComponent={Row} collection={this.collection} columns={columns} />
             </div>
         );

--- a/admin/src/Membership/KeyList.jsx
+++ b/admin/src/Membership/KeyList.jsx
@@ -6,8 +6,6 @@ import CollectionTable from "../Components/CollectionTable";
 import DateTimeShow from "../Components/DateTimeShow";
 import SearchBox from "../Components/SearchBox";
 
-const URL = "/membership/keys";
-
 const Row = props => {
     const {item} = props;
     return (
@@ -27,8 +25,8 @@ class KeyList extends React.Component {
         super(props);
         this.onSearch = this.onSearch.bind(this);
 
-        const params = new URLSearchParams(this.props.location.search);
-        const search_term = params.get('search') || '';
+        this.params = new URLSearchParams(this.props.location.search);
+        const search_term = this.params.get('search') || '';
         this.collection = new Collection({type: Key, expand: "member", search: search_term});
         this.state = {'search': search_term};
     }
@@ -36,8 +34,14 @@ class KeyList extends React.Component {
     onSearch(term) {
         this.setState({'search': term});
         this.collection.updateSearch(term);
-        this.props.history.replace(URL + "?search=" + term);
+        if (term === "") {
+            this.params.delete("search");
+        } else {
+            this.params.set("search", term);
+        }
+        this.props.history.replace(this.props.location.pathname + "?" + this.params.toString());
     }
+
 
     render() {
         const columns = [

--- a/admin/src/Membership/MemberList.jsx
+++ b/admin/src/Membership/MemberList.jsx
@@ -6,8 +6,6 @@ import Member from "../Models/Member";
 import CollectionTable from "../Components/CollectionTable";
 import SearchBox from "../Components/SearchBox";
 
-const URL = "/membership/members";
-
 const Row = props => {
     const {item, deleteItem} = props;
     return (
@@ -29,8 +27,8 @@ class MemberList extends React.Component {
         super(props);
         this.onSearch = this.onSearch.bind(this);
 
-        const params = new URLSearchParams(this.props.location.search);
-        const search_term = params.get('search') || '';
+        this.params = new URLSearchParams(this.props.location.search);
+        const search_term = this.params.get('search') || '';
         this.collection = new Collection({type: Member, search: search_term});
         this.state = {'search': search_term};
     }
@@ -38,8 +36,14 @@ class MemberList extends React.Component {
     onSearch(term) {
         this.setState({'search': term});
         this.collection.updateSearch(term);
-        this.props.history.replace(URL + "?search=" + term);
+        if (term === "") {
+            this.params.delete("search");
+        } else {
+            this.params.set("search", term);
+        }
+        this.props.history.replace(this.props.location.pathname + "?" + this.params.toString());
     }
+
 
     render() {
         const columns = [

--- a/admin/src/Membership/MemberList.jsx
+++ b/admin/src/Membership/MemberList.jsx
@@ -4,33 +4,9 @@ import Date from '../Components/DateShow';
 import Collection from "../Models/Collection";
 import Member from "../Models/Member";
 import CollectionTable from "../Components/CollectionTable";
+import SearchBox from "../Components/SearchBox";
 
-
-class SearchBox extends React.Component {
-    
-    constructor(props) {
-        super(props);
-    }
-    
-    render() {
-        return (
-            <div className="filterbox">
-                <div className="uk-grid">
-                    <div className="uk-width-2-3">
-                        <form className="uk-form">
-                            <div className="uk-form-icon">
-                                <i className="uk-icon-search"/>
-                                <input ref={c => this.search = c} tabIndex="1" type="text" className="uk-form-width-large" placeholder="Skriv in ett sökord"
-                                       onChange={() => this.props.onChange(this.search.value)} />
-                            </div>
-                        </form>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-}
-
+const URL = "/membership/members";
 
 const Row = props => {
     const {item, deleteItem} = props;
@@ -51,7 +27,18 @@ class MemberList extends React.Component {
 
     constructor(props) {
         super(props);
-        this.collection = new Collection({type: Member});
+        this.onSearch = this.onSearch.bind(this);
+
+        const params = new URLSearchParams(this.props.location.search);
+        const search_term = params.get('search') || '';
+        this.collection = new Collection({type: Member, search: search_term});
+        this.state = {'search': search_term};
+    }
+
+    onSearch(term) {
+        this.setState({'search': term});
+        this.collection.updateSearch(term);
+        this.props.history.replace(URL + "?search=" + term);
     }
 
     render() {
@@ -71,7 +58,7 @@ class MemberList extends React.Component {
                 <p className="uk-float-left">På denna sida ser du en lista på samtliga medlemmar.</p>
                 <Link to="/membership/members/add" className="uk-button uk-button-primary uk-float-right"><i className="uk-icon-plus-circle"/> Skapa ny medlem</Link>
 
-                <SearchBox onChange={terms => this.collection.updateSearch(terms)} />
+                <SearchBox handleChange={this.onSearch} />
                 <CollectionTable rowComponent={Row} collection={this.collection} columns={columns} />
             </div>
         );

--- a/admin/src/Models/Collection.js
+++ b/admin/src/Models/Collection.js
@@ -11,7 +11,7 @@ import * as _ from "underscore";
 // idListName: used for add and remove if collection supports it by pushing id list to to <url>/remove or <url>/add,
 //             this could be simpler if server handled removes in a better way
 export default class Collection {
-    constructor({type, pageSize = 25, expand = null, sort = {}, url=null, idListName=null}) {
+    constructor({type, pageSize = 25, expand = null, sort = {}, url=null, idListName=null, search=null}) {
         this.type = type;
         this.pageSize = pageSize;
         this.url = url || type.model.root;
@@ -20,7 +20,7 @@ export default class Collection {
         this.items = null;
         this.page = {index: 1, count: 1};
         this.sort = sort;
-        this.search = null;
+        this.search = search;
         this.expand = expand;
 
         this.subscribers = {};

--- a/admin/src/Sales/OrderList.js
+++ b/admin/src/Sales/OrderList.js
@@ -7,10 +7,6 @@ import DateTimeShow from "../Components/DateTimeShow";
 
 class SearchBox extends React.Component {
 
-    constructor(props) {
-        super(props);
-    }
-
     render() {
         return (
             <div className="filterbox">
@@ -19,8 +15,7 @@ class SearchBox extends React.Component {
                         <form className="uk-form">
                             <div className="uk-form-icon">
                                 <i className="uk-icon-search"/>
-                                <input ref={c => this.search = c} tabIndex="1" type="text" className="uk-form-width-large" placeholder="Skriv in ett sökord"
-                                       onChange={() => this.props.onChange(this.search.value)} />
+                                <input value={this.props.value} ref={c => this.search = c} tabIndex="1" type="text" className="uk-form-width-large" placeholder="Skriv in ett sökord" onChange={(e) => this.props.handleChange(e.target.value)} />
                             </div>
                         </form>
                     </div>
@@ -46,12 +41,27 @@ const Row = props => {
 
 
 class OrderList extends React.Component {
-    
+
+    componentDidMount() {
+        const params = new URLSearchParams(this.props.location.search);
+        const search_term = params.get('search');
+        this.setState({'search': search_term});
+        this.collection.updateSearch(search_term);
+    }
+
     constructor(props) {
         super(props);
         this.collection = new Collection({type: Order, url: "/webshop/transaction", expand: 'member'});
+        this.state = {'search': ''};
+        this.onSearch = this.onSearch.bind(this);
     }
-    
+
+    onSearch(term) {
+        this.setState({'search': term});
+        this.collection.updateSearch(term);
+        this.props.history.replace("/sales?search=" + term);
+    }
+
     render() {
         const columns = [
             {title: "Order"},
@@ -64,7 +74,7 @@ class OrderList extends React.Component {
         return (
             <div className="uk-margin-top">
                 <h2>Inkommna ordrar</h2>
-                <SearchBox onChange={terms => this.collection.updateSearch(terms)} />
+                <SearchBox handleChange={this.onSearch} value={this.state.search}/>
                 <CollectionTable emptyMessage="Ingar ordrar" rowComponent={Row} collection={this.collection} columns={columns} />
             </div>
         );

--- a/admin/src/Sales/OrderList.js
+++ b/admin/src/Sales/OrderList.js
@@ -5,6 +5,31 @@ import Collection from "../Models/Collection";
 import CollectionTable from "../Components/CollectionTable";
 import DateTimeShow from "../Components/DateTimeShow";
 
+class SearchBox extends React.Component {
+
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return (
+            <div className="filterbox">
+                <div className="uk-grid">
+                    <div className="uk-width-2-3">
+                        <form className="uk-form">
+                            <div className="uk-form-icon">
+                                <i className="uk-icon-search"/>
+                                <input ref={c => this.search = c} tabIndex="1" type="text" className="uk-form-width-large" placeholder="Skriv in ett sökord"
+                                       onChange={() => this.props.onChange(this.search.value)} />
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
 
 const Row = props => {
     const {item} = props;
@@ -39,6 +64,7 @@ class OrderList extends React.Component {
         return (
             <div className="uk-margin-top">
                 <h2>Inkommna ordrar</h2>
+                <SearchBox onChange={terms => this.collection.updateSearch(terms)} />
                 <CollectionTable emptyMessage="Ingar ordrar" rowComponent={Row} collection={this.collection} columns={columns} />
             </div>
         );

--- a/admin/src/Sales/OrderList.js
+++ b/admin/src/Sales/OrderList.js
@@ -12,7 +12,7 @@ class SearchBox extends React.Component {
             <div className="filterbox">
                 <div className="uk-grid">
                     <div className="uk-width-2-3">
-                        <form className="uk-form">
+                        <form className="uk-form" onSubmit={(e) => e.preventDefault()}>
                             <div className="uk-form-icon">
                                 <i className="uk-icon-search"/>
                                 <input value={this.props.value} ref={c => this.search = c} tabIndex="1" type="text" className="uk-form-width-large" placeholder="Skriv in ett sökord" onChange={(e) => this.props.handleChange(e.target.value)} />
@@ -45,7 +45,7 @@ class OrderList extends React.Component {
     componentDidMount() {
         const params = new URLSearchParams(this.props.location.search);
         const search_term = params.get('search');
-        this.setState({'search': search_term});
+        this.setState({'search': search_term || ''});
         this.collection.updateSearch(search_term);
     }
 

--- a/admin/src/Sales/OrderList.js
+++ b/admin/src/Sales/OrderList.js
@@ -6,8 +6,6 @@ import CollectionTable from "../Components/CollectionTable";
 import DateTimeShow from "../Components/DateTimeShow";
 import SearchBox from "../Components/SearchBox";
 
-const URL = "/sales";
-
 const Row = props => {
     const {item} = props;
     return (
@@ -28,8 +26,8 @@ class OrderList extends React.Component {
         super(props);
         this.onSearch = this.onSearch.bind(this);
 
-        const params = new URLSearchParams(this.props.location.search);
-        const search_term = params.get('search') || '';
+        this.params = new URLSearchParams(this.props.location.search);
+        const search_term = this.params.get('search') || '';
         this.collection = new Collection({type: Order, url: "/webshop/transaction", expand: 'member', search: search_term});
         this.state = {'search': search_term};
     }
@@ -37,7 +35,12 @@ class OrderList extends React.Component {
     onSearch(term) {
         this.setState({'search': term});
         this.collection.updateSearch(term);
-        this.props.history.replace(URL + "?search=" + term);
+        if (term === "") {
+            this.params.delete("search");
+        } else {
+            this.params.set("search", term);
+        }
+        this.props.history.replace(this.props.location.pathname + "?" + this.params.toString());
     }
 
     render() {

--- a/admin/src/Sales/OrderList.js
+++ b/admin/src/Sales/OrderList.js
@@ -4,27 +4,9 @@ import Order from "../Models/Order";
 import Collection from "../Models/Collection";
 import CollectionTable from "../Components/CollectionTable";
 import DateTimeShow from "../Components/DateTimeShow";
+import SearchBox from "../Components/SearchBox";
 
-class SearchBox extends React.Component {
-
-    render() {
-        return (
-            <div className="filterbox">
-                <div className="uk-grid">
-                    <div className="uk-width-2-3">
-                        <form className="uk-form" onSubmit={(e) => e.preventDefault()}>
-                            <div className="uk-form-icon">
-                                <i className="uk-icon-search"/>
-                                <input value={this.props.value} ref={c => this.search = c} tabIndex="1" type="text" className="uk-form-width-large" placeholder="Skriv in ett sökord" onChange={(e) => this.props.handleChange(e.target.value)} />
-                            </div>
-                        </form>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-}
-
+const URL = "/sales";
 
 const Row = props => {
     const {item} = props;
@@ -55,7 +37,7 @@ class OrderList extends React.Component {
     onSearch(term) {
         this.setState({'search': term});
         this.collection.updateSearch(term);
-        this.props.history.replace("/sales?search=" + term);
+        this.props.history.replace(URL + "?search=" + term);
     }
 
     render() {

--- a/admin/src/Sales/OrderList.js
+++ b/admin/src/Sales/OrderList.js
@@ -42,18 +42,14 @@ const Row = props => {
 
 class OrderList extends React.Component {
 
-    componentDidMount() {
-        const params = new URLSearchParams(this.props.location.search);
-        const search_term = params.get('search');
-        this.setState({'search': search_term || ''});
-        this.collection.updateSearch(search_term);
-    }
-
     constructor(props) {
         super(props);
-        this.collection = new Collection({type: Order, url: "/webshop/transaction", expand: 'member'});
-        this.state = {'search': ''};
         this.onSearch = this.onSearch.bind(this);
+
+        const params = new URLSearchParams(this.props.location.search);
+        const search_term = params.get('search') || '';
+        this.collection = new Collection({type: Order, url: "/webshop/transaction", expand: 'member', search: search_term});
+        this.state = {'search': search_term};
     }
 
     onSearch(term) {

--- a/api/src/shop/entities.py
+++ b/api/src/shop/entities.py
@@ -23,6 +23,7 @@ product_image_entity = ProductImageEntity(
 transaction_entity = Entity(
     Transaction,
     expand_fields={'member': ExpandField(Transaction.member, [Member.firstname, Member.lastname, Member.member_number])},
+    search_columns=('id', 'created_at', 'status', 'member_id', 'amount'),
 )
 
 


### PR DESCRIPTION
# Before
Search terms were lost when moving from a page and back again.

# After
1. Search terms are saved in history history. Thus, one can jump back and forward between pages but still keep the search string.
    ![image](https://user-images.githubusercontent.com/7572427/106058191-37885b00-60f1-11eb-8bdf-ba420c7c976e.png)
2. Added a search box to the page that lists orders.
