### PR TITLE
Fix highlights in sidebar menu

### DIFF
--- a/public/scss/style.scss
+++ b/public/scss/style.scss
@@ -61,6 +61,10 @@ body {
                 max-width: 250px;
             }
         }
+
+        li a {
+            justify-content: center;
+        }
     }
 
     // Required for the delete button to be placed on the same row as the category
@@ -81,6 +85,20 @@ body {
         a {
             color: #FFF;
         }
+    }
+
+    li.active > a {
+        color: #444 !important;
+    }
+
+    li a {
+        .uk-icon {
+            margin-right: 10px;
+        }
+
+        display: flex;
+        flex-direction: row;
+        align-items: center;
     }
 
     .sidebar-buy-btn.cart-empty {

--- a/public/scss/style.scss
+++ b/public/scss/style.scss
@@ -88,7 +88,7 @@ body {
     }
 
     li.active > a {
-        color: #444 !important;
+        color: #444;
     }
 
     li a {

--- a/public/src/templates/sidebar.html
+++ b/public/src/templates/sidebar.html
@@ -30,7 +30,7 @@
                 {% call nav_item("history", active_item) %}
                     <a href="/shop/member/history"><span uk-icon="history"></span> Min köphistorik</a>
                 {% endcall %}
-                {% call nav_item("history", active_item) %}
+                {% call nav_item("licenses", active_item) %}
                     <a href="/shop/member/licenses"><span uk-icon="tag"></span> Licenser och rabatter</a>
                 {% endcall %}
                 <li>


### PR DESCRIPTION
- Fix 'licenses' menu item was highlighted when on the wrong page
- Fix sidebar menu highlights

Current:
![image](https://user-images.githubusercontent.com/1144597/133689429-f371d635-77ed-4be3-87df-0c4aa9183557.png)

New:
![image](https://user-images.githubusercontent.com/1144597/133689384-1a8c5f51-d0e5-45a9-ade0-8dc0e70b3945.png)
