### PR TITLE
Fix/link highlight

### DIFF
--- a/admin/src/Membership/GroupBox.jsx
+++ b/admin/src/Membership/GroupBox.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Link } from "react-router-dom";
 import { withRouter} from 'react-router';
+import { NavItem } from "../nav";
 import PropTypes from 'prop-types';
 import Group from "../Models/Group";
 
@@ -36,9 +36,9 @@ class GroupBox extends React.Component {
                 <h2>Grupp {title}</h2>
 
                 <ul className="uk-tab">
-                    <li><Link to={"/membership/groups/" + group_id + "/info"}>Information</Link></li>
-                    <li><Link to={"/membership/groups/" + group_id + "/members"}>Medlemmar</Link></li>
-                    <li><Link to={"/membership/groups/" + group_id + "/permissions"}>Behörigheter</Link></li>
+                    <NavItem icon={null} to={"/membership/groups/" + group_id + "/info"}>Information</NavItem>
+                    <NavItem icon={null} to={"/membership/groups/" + group_id + "/members"}>Medlemmar</NavItem>
+                    <NavItem icon={null} to={"/membership/groups/" + group_id + "/permissions"}>Behörigheter</NavItem>
                 </ul>
                 {this.props.children}
             </div>

--- a/admin/src/Membership/MemberBox.jsx
+++ b/admin/src/Membership/MemberBox.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from "react-router-dom";
+import { NavItem } from "../nav";
 import { withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import Member from "../Models/Member";
@@ -36,13 +36,13 @@ class MemberBox extends React.Component {
                 <h2>Medlem #{member_number}: {firstname} {lastname}</h2>
 
                 <ul className="uk-tab">
-                    <li><Link to={"/membership/members/" + member_id + "/member-data"}>Uppgifter</Link></li>
-                    <li><Link to={"/membership/members/" + member_id + "/groups"}>Grupper</Link></li>
-                    <li><Link to={"/membership/members/" + member_id + "/keys"}>Nycklar</Link></li>
-                    <li><Link to={"/membership/members/" + member_id + "/permissions"}>Behörigheter</Link></li>
-                    <li><Link to={"/membership/members/" + member_id + "/orders"}>Ordrar</Link></li>
-                    <li><Link to={"/membership/members/" + member_id + "/messages"}>Utskick</Link></li>
-                    <li><Link to={"/membership/members/" + member_id + "/spans"}>Perioder</Link></li>
+                    <NavItem to={"/membership/members/" + member_id + "/member-data"}>Uppgifter</NavItem>
+                    <NavItem to={"/membership/members/" + member_id + "/groups"}>Grupper</NavItem>
+                    <NavItem to={"/membership/members/" + member_id + "/keys"}>Nycklar</NavItem>
+                    <NavItem to={"/membership/members/" + member_id + "/permissions"}>Behörigheter</NavItem>
+                    <NavItem to={"/membership/members/" + member_id + "/orders"}>Ordrar</NavItem>
+                    <NavItem to={"/membership/members/" + member_id + "/messages"}>Utskick</NavItem>
+                    <NavItem to={"/membership/members/" + member_id + "/spans"}>Perioder</NavItem>
                 </ul>
                 {this.props.children}
             </div>

--- a/admin/src/nav.jsx
+++ b/admin/src/nav.jsx
@@ -5,12 +5,12 @@ import { Link, NavLink } from 'react-router-dom';
 
 
 export const NavItem = withRouter(props => {
-    const { location, icon, text, target } = props;
+    const { location, icon, to } = props;
 
     return (
-        <li className={location.pathname.indexOf(target) >= 0 ? "uk-active" : ""}>
-            <NavLink to={target}>
-                {icon ? <><i className={"uk-icon-" + icon} />&nbsp;</> : null }<span>{text}</span>
+        <li className={location.pathname.indexOf(to) >= 0 ? "uk-active" : ""}>
+            <NavLink to={to}>
+                {icon ? <><i className={"uk-icon-" + icon} />&nbsp;</> : null }<span>{props.children}</span>
             </NavLink>
         </li>
     );
@@ -22,7 +22,7 @@ export const Nav = ({ nav: { brand, items } }) => (
         <div className="uk-container uk-container-center">
             <Link to="/" className="uk-navbar-brand">{brand}</Link>
             <ul className="uk-navbar-nav uk-navbar-attached">
-                {items.map((item, i) => <NavItem target={item.target} text={item.text} icon={item.icon} key={i} />)}
+                {items.map((item, i) => <NavItem to={item.target} icon={item.icon} key={i}>{item.text}</NavItem>)}
             </ul>
         </div>
     </nav>
@@ -50,7 +50,7 @@ export const SideNav = withRouter(({ nav, location }) => {
                         return (<li key={i} className="uk-nav-header">{item.text}</li>);
                     }
 
-                    return (<NavItem key={i} target={item.target} text={item.text} icon={item.icon} activeItem={activeItem} />);
+                    return (<NavItem key={i} to={item.target} icon={item.icon} activeItem={activeItem}>{item.text}</NavItem>);
                 })}
             </ul>
         </div>

--- a/admin/src/nav.jsx
+++ b/admin/src/nav.jsx
@@ -4,14 +4,13 @@ import { withRouter, matchPath } from 'react-router';
 import { Link, NavLink } from 'react-router-dom';
 
 
-const NavItem = withRouter(props => {
-    const { item } = props;
-    const { target, text, icon } = item;
+export const NavItem = withRouter(props => {
+    const { location, icon, text, target } = props;
 
     return (
-        <li>
-            <NavLink activeClassName="uk-active" to={target}>
-                <i className={"uk-icon-" + icon} />&nbsp;<span>{text}</span>
+        <li className={location.pathname.indexOf(target) >= 0 ? "uk-active" : ""}>
+            <NavLink to={target}>
+                {icon ? <><i className={"uk-icon-" + icon} />&nbsp;</> : null }<span>{text}</span>
             </NavLink>
         </li>
     );
@@ -23,7 +22,7 @@ export const Nav = ({ nav: { brand, items } }) => (
         <div className="uk-container uk-container-center">
             <Link to="/" className="uk-navbar-brand">{brand}</Link>
             <ul className="uk-navbar-nav uk-navbar-attached">
-                {items.map((item, i) => <NavItem item={item} key={i} />)}
+                {items.map((item, i) => <NavItem target={item.target} text={item.text} icon={item.icon} key={i} />)}
             </ul>
         </div>
     </nav>
@@ -51,7 +50,7 @@ export const SideNav = withRouter(({ nav, location }) => {
                         return (<li key={i} className="uk-nav-header">{item.text}</li>);
                     }
 
-                    return (<NavItem key={i} item={item} activeItem={activeItem} />);
+                    return (<NavItem key={i} target={item.target} text={item.text} icon={item.icon} activeItem={activeItem} />);
                 })}
             </ul>
         </div>


### PR DESCRIPTION
## Changes
* Fix so that active nav items are highlighted (based on target URL)

## Before
![image](https://user-images.githubusercontent.com/7572427/158909666-7c8bed3d-8d6d-4851-9146-5b32db115fb0.png)
## After
![image](https://user-images.githubusercontent.com/7572427/158909510-ddf8c9a7-11f5-4faa-b4e1-cc51d8754a79.png)

## Known issue
Does not work when standing on the parent "landing page" (like `/membership` which actually points to `/membership/members`).