### PR TITLE
Fix span sorting

### DIFF
--- a/admin/src/Models/Span.js
+++ b/admin/src/Models/Span.js
@@ -68,8 +68,7 @@ export const mergePeriods = toMergePeriods => {
 
 // Filter not deleted spans for one category, return sorted.
 export const filterCategory = (spans, category) =>
-    spans.filter(i => !i.deleted_at &&  i.type === category).sort();
-
+    spans.filter(i => !i.deleted_at &&  i.type === category).sort((a, b) => a.start - b.start);
 
 // Return assembled periods for non deleted spans in a category.
 export const filterPeriods = (spans, category) => {

--- a/admin/src/Models/Span.js
+++ b/admin/src/Models/Span.js
@@ -68,12 +68,11 @@ export const mergePeriods = toMergePeriods => {
 
 // Filter not deleted spans for one category, return sorted.
 export const filterCategory = (spans, category) =>
-    spans.filter(i => !i.deleted_at &&  i.type === category).sort((a, b) => a.startdate > b.startdate);
+    spans.filter(i => !i.deleted_at &&  i.type === category).sort();
 
 
 // Return assembled periods for non deleted spans in a category.
 export const filterPeriods = (spans, category) => {
-    spans.sort((a, b) => a.start > b.start ? 1 : -1);
     return mergePeriods(filterCategory(spans, category));
 };
 


### PR DESCRIPTION
The old span storting was broken as it behaved differently in different browsers. Since we sort strings anyway no compare function should be needed, and since we use ISO date formating charactere sorting should be fine. 

Other than displaying the correct spans this change will also start merging spans again as it uses the same function.