### PR TITLE
Fix recursive PYTEST_PARAMS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 COMPOSE=docker-compose
 TEST_COMPOSE=docker-compose -p test -f docker-compose.yml -f docker-compose.test.yml
 DEV_COMPOSE=docker-compose -f docker-compose.yml -f docker-compose.dev.yml
-PYTEST_PARAMS?=$(PYTEST_PARAMS)
+PYTEST_PARAMS?=
 
 -include local.mk
 


### PR DESCRIPTION
Fix for recursive variable when PYTEST_PARAMS is not already set 

```
$ make dev-test
Makefile:5: *** Recursive variable 'PYTEST_PARAMS' references itself (eventually).  Stop.
```