### PR TITLE
Fix firstrun.py y/n prompt being deceptively case-sensitive

### DIFF
--- a/api/src/firstrun.py
+++ b/api/src/firstrun.py
@@ -65,7 +65,7 @@ def create_admin(admins):
 
     s = input("Do you want to create a new admin user"
               " (you can later use the create_user.py script to create users)? [Y/n]: ")
-    if s not in {"", "y", "yes"}:
+    if s.lower() not in {"", "y", "yes"}:
         return
 
     while True:


### PR DESCRIPTION
The prompt suggests `[Y/n]` where the upper-case one is the default and the lower-case one is the secondary option, but it also suggests any casing should work fine, when it didn't! Blasphemous.