### PR TITLE
chore: upgrade mysql image to support arm architecture

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   db2:
-    image: mysql:8.0.28
+    image: mysql:8.0.33
     # The lumen library seems to use an older mysql client which is not able to connect if mysql uses the newer caching_sha2_password authentication plugin.
     # Therefore we need to override the mysql starting command to set a config option to use the older password authentication plugin.
     command: mysqld --default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
https://hub.docker.com/r/arm64v8/mysql/tags

Mysql image has supported arm since 8.0.29, but I was thinking of updating it to the latest minor version. 