### PR TITLE
Remove conflicting dependency preact-compat

### DIFF
--- a/public/package.json
+++ b/public/package.json
@@ -25,7 +25,6 @@
         "markdown-it": "^12.2.0",
         "npm": "^9.2.0",
         "preact": "^10.15.1",
-        "preact-compat": "^3.19.0",
         "react-calendly": "^4.1.1"
     },
     "scripts": {


### PR DESCRIPTION
As explained in https://github.com/preactjs/preact-compat , preact-compat is no longer necessary.

This fixes a build issue when running `make firstrun` multiple times, as it was showing conflicting dependencies.

So far I have seen no problem related to missing that package.