### PR TITLE
Query only the discount coupon that is asked for instead of all

### DIFF
--- a/api/src/shop/stripe_discounts.py
+++ b/api/src/shop/stripe_discounts.py
@@ -20,7 +20,7 @@ class Discount:
     fraction_off: Decimal
 
 
-DISCOUNT_FRACTIONS: Optional[Dict[PriceLevel, Discount]] = None
+DISCOUNT_FRACTIONS: Optional[Dict[PriceLevel, Discount]] = {price_level: None for price_level in PriceLevel}
 
 
 def get_price_level_for_member(member: "Member") -> PriceLevel:
@@ -39,9 +39,8 @@ def get_discount_for_product(product: "Product", price_level: PriceLevel) -> Dis
 
 def get_discount_fraction_off(price_level: PriceLevel) -> Discount:
     global DISCOUNT_FRACTIONS
-    if DISCOUNT_FRACTIONS is None:
-        DISCOUNT_FRACTIONS = {price_level: _query_discount_fraction_off(price_level) for price_level in PriceLevel}
-
+    if DISCOUNT_FRACTIONS[price_level] is None:
+        DISCOUNT_FRACTIONS[price_level] = _query_discount_fraction_off(price_level)
     return DISCOUNT_FRACTIONS[price_level]
 
 

--- a/api/src/shop/stripe_discounts.py
+++ b/api/src/shop/stripe_discounts.py
@@ -38,7 +38,6 @@ def get_discount_for_product(product: "Product", price_level: PriceLevel) -> Dis
 
 
 def get_discount_fraction_off(price_level: PriceLevel) -> Discount:
-    global DISCOUNT_FRACTIONS
     if DISCOUNT_FRACTIONS[price_level] is None:
         DISCOUNT_FRACTIONS[price_level] = _query_discount_fraction_off(price_level)
     return DISCOUNT_FRACTIONS[price_level]


### PR DESCRIPTION
This change makes two tests not have to query stripe for all the coupon so they pass since they only use the normal price level. We could improve these tests more as a part of #331 so that the tests also run with discounted transactions.

The two affected tests are
test_reminder_message_is_not_created_if_member_has_pending_membership_days
test_reminder_message_is_not_created_if_member_has_pending_labaccess_days