### PR TITLE
Make memeber id nullable in Transaction table

### DIFF
--- a/admin/src/Sales/OrderList.js
+++ b/admin/src/Sales/OrderList.js
@@ -17,7 +17,7 @@ const Row = props => {
             <td>
               {item.member_id
                 ? <Link to={"/membership/members/" + item.member_id}>#{item.member_number}: {item.firstname} {item.lastname}</Link>
-                  : "Gift card"
+                  : "Gift"
               }
             </td>
             <td className='uk-text-right'>{item.amount} kr</td>

--- a/admin/src/Sales/OrderList.js
+++ b/admin/src/Sales/OrderList.js
@@ -14,7 +14,12 @@ const Row = props => {
             <td><Link to={"/sales/order/" + item.id}>{item.id}</Link></td>
             <td><DateTimeShow date={item.created_at}/></td>
             <td>{item.status}</td>
-            <td><Link to={"/membership/members/" + item.member_id}>#{item.member_number}: {item.firstname} {item.lastname}</Link></td>
+            <td>
+              {item.member_id
+                ? <Link to={"/membership/members/" + item.member_id}>#{item.member_number}: {item.firstname} {item.lastname}</Link>
+                  : "Gift card"
+              }
+            </td>
             <td className='uk-text-right'>{item.amount} kr</td>
         </tr>
     );

--- a/api/src/firstrun.py
+++ b/api/src/firstrun.py
@@ -305,9 +305,43 @@ def create_shop_transactions():
                     
                 ),
             )
-            index += 1 
+            index += 1
+
+    # A transaction with member_id as null to represent a gift card.
+    transaction = get_or_create(
+        Transaction,
+        id=index,
+        defaults=dict(
+            member_id=None,
+            amount=100,
+            status="completed",
+            created_at=datetime.now()
+        ),
+    )
+    transaction_content = get_or_create(
+        TransactionContent,
+        id=index,
+        defaults=dict(
+            transaction_id=transaction.id,
+            product_id=product.id,
+            count=1,
+            amount=100,
+        ),
+    )
+    get_or_create(
+        TransactionAction,
+        id=index,
+        defaults=dict(
+            content_id=transaction_content.id,
+            action_type="add_labaccess_days",
+            value=10,
+            status="completed",
+            completed_at=datetime.now(),
+        ),
+    )
+    index += 1
     
-        db_session.commit()
+    db_session.commit()
 
 def create_shop_accounts_cost_centers():
     banner(BLUE, "Creating Fake Account and Cost Centers")

--- a/api/src/firstrun.py
+++ b/api/src/firstrun.py
@@ -323,7 +323,7 @@ def create_shop_transactions():
         id=index,
         defaults=dict(
             transaction_id=transaction.id,
-            product_id=product.id,
+            product_id=products[0].id,
             count=1,
             amount=100,
         ),
@@ -368,7 +368,7 @@ def create_shop_accounts_cost_centers():
 
 
 def create_shop_gift_cards():
-    banner(YELLOW, "Creating Fake Gift Cards and Gift Card & Product Mappings")
+    banner(YELLOW, "Creating Fake 'Gift Cards' and 'Gift Card & Product Mappings'")
 
     gift_card = get_or_create(
         GiftCard,

--- a/api/src/migrations/0025_initial_gift_card.sql
+++ b/api/src/migrations/0025_initial_gift_card.sql
@@ -21,3 +21,6 @@ CREATE TABLE IF NOT EXISTS `webshop_product_gift_card_mapping` (
     KEY `product_id_index` (`product_id`),
     CONSTRAINT `product_id_foreign` FOREIGN KEY (`product_id`) REFERENCES `webshop_products` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Make member_id nullable in Transactions, to enable Gift card purchasable without being a member
+ALTER TABLE `webshop_transactions` MODIFY COLUMN member_id int(10) unsigned NULL;

--- a/api/src/shop/models.py
+++ b/api/src/shop/models.py
@@ -126,7 +126,7 @@ class Transaction(Base):
     FAILED = "failed"
 
     id = Column(Integer, primary_key=True, nullable=False, autoincrement=True)
-    member_id = Column(Integer, ForeignKey(Member.member_id), nullable=False)
+    member_id = Column(Integer, ForeignKey(Member.member_id), nullable=True)
     amount = Column(Numeric(precision="15,2"), nullable=False)
     status = Column(Enum(PENDING, COMPLETED, FAILED), nullable=False)
     created_at = Column(DateTime, server_default=func.now())


### PR DESCRIPTION
Related to Issue #206 
Member_id is now null-able in transactions table and Transactions with null member_id handled in 'Sales' tab of admins page.