### PR TITLE
fixed a ValueError exception on statistics page

### DIFF
--- a/api/src/quiz/views.py
+++ b/api/src/quiz/views.py
@@ -292,7 +292,7 @@ def quiz_statistics(quiz_id: int):
         # Maximum number members that have answered any question.
         # This ensures we also account for questions added later (which may not have as many answers)
         # We iterate through the questions list to ensure we dont count deleted questions
-        "answered_quiz_member_count": max([answers_by_question.get(question.id, 0) for question in questions]),
+        "answered_quiz_member_count": max([answers_by_question.get(question.id, 0) for question in questions], default=0),
         "questions": [
             {
                 "question": quiz_question_entity.to_obj(question),


### PR DESCRIPTION
Fixed a ValueError exception that was being thrown on loading the statistics page in "local development setup".


^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
makeradmin-api-1               |   File "/work/src/service/internal_service.py", line 79, in view_wrapper
makeradmin-api-1               |     data = f(*args, **kwargs)
makeradmin-api-1               |            ^^^^^^^^^^^^^^^^^^
makeradmin-api-1               |   File "/work/src/quiz/views.py", line 295, in quiz_statistics
makeradmin-api-1               |     "answered_quiz_member_count": max([answers_by_question.get(question.id, 0) for question in questions]),
makeradmin-api-1               |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
makeradmin-api-1               | ValueError: max() arg is an empty sequence
makeradmin-api-1               | []