### PR TITLE
Run GHA also on PR

### DIFF
--- a/.github/workflows/makeradmin.yml
+++ b/.github/workflows/makeradmin.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '**'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   test:


### PR DESCRIPTION
I think this should fix so that third-party contributors also can run GHA in their pull-requests ([after having been approved](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)).