### PR TITLE
Filtered out gift cards from pending_actions_query

### DIFF
--- a/api/src/shop/transactions.py
+++ b/api/src/shop/transactions.py
@@ -158,6 +158,9 @@ def pending_actions_query(member_id: Optional[int] = None, transaction: Optional
 
     if member_id:
         query = query.filter(Transaction.member_id == member_id)
+    else:
+        # Exclude transactions with member_id set to None (Gift cards)
+        query = query.filter(Transaction.member_id.isnot(None))
 
     return query
 

--- a/api/src/shop/transactions.py
+++ b/api/src/shop/transactions.py
@@ -156,7 +156,7 @@ def pending_actions_query(member_id: Optional[int] = None, transaction: Optional
     if transaction:
         query = query.filter(Transaction.id == transaction.id)
 
-    if member_id:
+    if member_id is not None:
         query = query.filter(Transaction.member_id == member_id)
     else:
         # Exclude transactions with member_id set to None (Gift cards)


### PR DESCRIPTION
GiftCards with be "shipped" using the validation code that the customer is emailed when making a gift card purchase. Hence they don't need to be shipped in the traditional way membership days and access are shipped.

I'm pretty sure this closes issue #369 