### PR TITLE
Email for personal info update

### DIFF
--- a/admin/src/Membership/MemberBoxMemberData.jsx
+++ b/admin/src/Membership/MemberBoxMemberData.jsx
@@ -1,11 +1,16 @@
-import React from "react";
 import PropTypes from "prop-types";
-import Member from "../Models/Member";
-import MemberForm from "../Components/MemberForm";
-import { confirmModal } from "../message";
+import React from "react";
 import { withRouter } from "react-router";
+import MemberForm from "../Components/MemberForm";
+import Member from "../Models/Member";
+import auth from "../auth";
+import { confirmModal } from "../message";
 
 class MemberBoxMemberData extends React.Component {
+    update_member_info(member_id) {
+        auth.update_member_info(member_id);
+    }
+
     render() {
         const { router } = this.props;
 
@@ -13,7 +18,10 @@ class MemberBoxMemberData extends React.Component {
             <div className="uk-margin-top">
                 <MemberForm
                     member={this.context.member}
-                    onSave={() => this.context.member.save()}
+                    onSave={() => {
+                        this.update_member_info(this.context.member.member_id);
+                        this.context.member.save();
+                    }}
                     onDelete={() => {
                         const { member } = this.context;
                         return confirmModal(member.deleteConfirmMessage())

--- a/admin/src/Membership/MemberBoxMemberData.jsx
+++ b/admin/src/Membership/MemberBoxMemberData.jsx
@@ -3,14 +3,9 @@ import React from "react";
 import { withRouter } from "react-router";
 import MemberForm from "../Components/MemberForm";
 import Member from "../Models/Member";
-import auth from "../auth";
 import { confirmModal } from "../message";
 
 class MemberBoxMemberData extends React.Component {
-    update_member_info(member_id) {
-        auth.update_member_info(member_id);
-    }
-
     render() {
         const { router } = this.props;
 
@@ -19,7 +14,6 @@ class MemberBoxMemberData extends React.Component {
                 <MemberForm
                     member={this.context.member}
                     onSave={() => {
-                        this.update_member_info(this.context.member.member_id);
                         this.context.member.save();
                     }}
                     onDelete={() => {

--- a/admin/src/Models/Member.js
+++ b/admin/src/Models/Member.js
@@ -6,7 +6,7 @@ export default class Member extends Base {
         return `Are you sure you want to delete member ${this.firstname} ${this.lastname}?`;
     }
 
-    save() {
+    maybe_inform_member_before_changed_info() {
         if (Object.prototype.hasOwnProperty.call(this.unsaved, "email")) {
             post({
                 url: "/member/send_updated_member_info",
@@ -20,6 +20,10 @@ export default class Member extends Base {
                 expectedDataStatus: "ok",
             });
         }
+    }
+
+    save() {
+        this.maybe_inform_member_before_changed_info();
         super.save();
     }
 

--- a/admin/src/Models/Member.js
+++ b/admin/src/Models/Member.js
@@ -10,13 +10,17 @@ export default class Member extends Base {
         if (Object.prototype.hasOwnProperty.call(this.unsaved, "email")) {
             post({
                 url: "/member/send_updated_member_info",
-                data: { member_id: this.member_id },
+                data: {
+                    member_id: this.member_id,
+                    msg_swe: `Din epost ändrades från ${this.saved.email} till ${this.unsaved.email}`,
+                    msg_en: `Your email was updated from ${this.saved.email} to ${this.unsaved.email}`,
+                },
                 errorMessage:
                     "Error when sending email about updated information.",
                 expectedDataStatus: "ok",
             });
         }
-        return super.save();
+        super.save();
     }
 
     canSave() {

--- a/admin/src/Models/Member.js
+++ b/admin/src/Models/Member.js
@@ -7,7 +7,11 @@ export default class Member extends Base {
 
     canSave() {
         return (
-            this.isDirty() && this.email.length > 0 && this.firstname.length > 0
+            this.isDirty() &&
+            this.firstname.length > 0 &&
+            this.email.length > 0 &&
+            this.email.includes("@") &&
+            this.email.includes(".")
         );
     }
 }

--- a/admin/src/Models/Member.js
+++ b/admin/src/Models/Member.js
@@ -1,8 +1,22 @@
+import { post } from "../gateway";
 import Base from "./Base";
 
 export default class Member extends Base {
     deleteConfirmMessage() {
         return `Are you sure you want to delete member ${this.firstname} ${this.lastname}?`;
+    }
+
+    save() {
+        if (Object.prototype.hasOwnProperty.call(this.unsaved, "email")) {
+            post({
+                url: "/member/send_updated_member_info",
+                data: { member_id: this.member_id },
+                errorMessage:
+                    "Error when sending email about updated information.",
+                expectedDataStatus: "ok",
+            });
+        }
+        return super.save();
     }
 
     canSave() {

--- a/admin/src/auth.js
+++ b/admin/src/auth.js
@@ -148,15 +148,6 @@ class Auth {
             });
     }
 
-    update_member_info(member_id) {
-        post({
-            url: "/member/send_updated_member_info",
-            data: { member_id },
-            errorMessage: "Error when sending email about updated information.",
-            expectedDataStatus: "ok",
-        });
-    }
-
     onChange() {}
 }
 

--- a/admin/src/auth.js
+++ b/admin/src/auth.js
@@ -1,5 +1,5 @@
-import { showError, showSuccess } from "./message";
 import { post } from "./gateway";
+import { showError, showSuccess } from "./message";
 
 class Auth {
     getAccessToken() {
@@ -146,6 +146,15 @@ class Auth {
                     "<h2>Inloggningen misslyckades</h2>Kunde inte kommunicera med servern.",
                 );
             });
+    }
+
+    update_member_info(member_id) {
+        post({
+            url: "/member/send_updated_member_info",
+            data: { member_id },
+            errorMessage: "Error when sending email about updated information.",
+            expectedDataStatus: "ok",
+        });
     }
 
     onChange() {}

--- a/api/src/member/member.py
+++ b/api/src/member/member.py
@@ -34,15 +34,20 @@ def send_access_token_email(redirect, user_identification, ip, browser):
     return {"status": "sent"}
 
 
-def send_updated_member_info_email(member_id):
+def send_updated_member_info_email(member_id: int, msg_swe: str, msg_en: str):
     member = db_session.query(Member).get(member_id)
 
-    logger.info(f"sending email about updated personal information to member_id {member.member_id}")
+    logger.info(
+        f"sending email about updated personal information to member_id {member.member_id} with message {msg_en=},"
+        f" {msg_swe=}"
+    )
 
     send_message(
         MessageTemplate.UPDATED_MEMBER_INFO,
         member,
         now=format_datetime(datetime.now()),
+        message_swe=msg_swe,
+        message_en=msg_en,
     )
 
     return {"status": "sent"}

--- a/api/src/member/member.py
+++ b/api/src/member/member.py
@@ -34,6 +34,20 @@ def send_access_token_email(redirect, user_identification, ip, browser):
     return {"status": "sent"}
 
 
+def send_updated_member_info_email(member_id):
+    member = db_session.query(Member).get(member_id)
+
+    logger.info(f"sending email about updated personal information to member_id {member.member_id}")
+
+    send_message(
+        MessageTemplate.UPDATED_MEMBER_INFO,
+        member,
+        now=format_datetime(datetime.now()),
+    )
+
+    return {"status": "sent"}
+
+
 def set_pin_code(member_id: int, pin_code: str):
     member: Member = db_session.query(Member).get(member_id)
     member.pin_code = pin_code

--- a/api/src/member/views.py
+++ b/api/src/member/views.py
@@ -1,16 +1,15 @@
-import time
-
 from change_phone_request import change_phone_request, change_phone_validate
 from flask import g, request
 from membership.member_auth import get_member_permissions
 from membership.membership import get_access_summary, get_membership_summary
+from membership.models import Member
 from membership.views import member_entity
 from quiz.views import member_quiz_statistics
-from service.api_definition import GET, POST, PUBLIC, USER, Arg, natural1, non_empty_str
+from service.api_definition import GET, MEMBER_EDIT, POST, PUBLIC, USER, Arg, natural1, non_empty_str
 from service.error import Unauthorized
 
 from member import service
-from member.member import get_member_groups, send_access_token_email, set_pin_code
+from member.member import get_member_groups, send_access_token_email, send_updated_member_info_email, set_pin_code
 
 
 @service.route("/send_access_token", method=POST, permission=PUBLIC)
@@ -19,6 +18,12 @@ def send_access_token(redirect=Arg(str, required=False), user_identification: st
     return send_access_token_email(
         redirect or "/member", user_identification, request.remote_addr, request.user_agent.string
     )
+
+
+@service.route("/send_updated_member_info", method=POST, permission=MEMBER_EDIT)
+def send_updated_member_info(member_id: int = Arg(int)):
+    """Send email to user with information that personal information has been updated."""
+    return send_updated_member_info_email(member_id)
 
 
 @service.route("/current", method=GET, permission=USER)

--- a/api/src/member/views.py
+++ b/api/src/member/views.py
@@ -5,7 +5,7 @@ from membership.membership import get_access_summary, get_membership_summary
 from membership.models import Member
 from membership.views import member_entity
 from quiz.views import member_quiz_statistics
-from service.api_definition import GET, MEMBER_EDIT, POST, PUBLIC, USER, Arg, natural1, non_empty_str
+from service.api_definition import GET, MESSAGE_SEND, POST, PUBLIC, USER, Arg, natural1, non_empty_str
 from service.error import Unauthorized
 
 from member import service
@@ -20,10 +20,10 @@ def send_access_token(redirect=Arg(str, required=False), user_identification: st
     )
 
 
-@service.route("/send_updated_member_info", method=POST, permission=MEMBER_EDIT)
-def send_updated_member_info(member_id: int = Arg(int)):
+@service.route("/send_updated_member_info", method=POST, permission=MESSAGE_SEND)
+def send_updated_member_info(member_id: int = Arg(int), msg_swe: str = Arg(str), msg_en: str = Arg(str)):
     """Send email to user with information that personal information has been updated."""
-    return send_updated_member_info_email(member_id)
+    return send_updated_member_info_email(member_id, msg_swe, msg_en)
 
 
 @service.route("/current", method=GET, permission=USER)

--- a/api/src/messages/models.py
+++ b/api/src/messages/models.py
@@ -25,6 +25,7 @@ class MessageTemplate(enum.Enum):
     MEMBERSHIP_REMINDER = "membership_reminder"
     NEW_LOW_INCOME_MEMBER = "new_low_income_member"
     GIFT_CARD_PURCHASE = "gift_card_purchase"
+    UPDATED_MEMBER_INFO = "updated_member_info"
 
 
 class Message(Base):

--- a/api/src/templates/updated_member_info.body.html
+++ b/api/src/templates/updated_member_info.body.html
@@ -8,6 +8,10 @@
     in på din <a href="{{ public_url('/member') }}">Stockholm Makerspace medlemssida</a>.
 </p>
 
+{% if message_swe %}
+{{ message_swe }}
+{% endif %}
+
 <p>Med vänliga hälsningar,<br />Stockholm Makerspace</p>
 {% endblock %}
 
@@ -16,6 +20,10 @@
     Your personal information has been updated. If this was incorrect you should have a look at your personal
     information by logging in to your <a href="{{ public_url('/member') }}">Stockholm Makerspace medlemssida</a>.
 </p>
+
+{% if message_en %}
+{{ message_en }}
+{% endif %}
 
 <p>Sincerely,<br />Stockholm Makerspace</p>
 {% endblock %}

--- a/api/src/templates/updated_member_info.body.html
+++ b/api/src/templates/updated_member_info.body.html
@@ -1,0 +1,21 @@
+{% extends "email_body_base.html" %}
+
+{% block swedish %}
+<p>Hej {{ member.firstname }},</p>
+<p>(See below for English).</p>
+<p>
+    Dina personliga uppgifter har uppdaterats. Om detta inte var korrekt bör du se över dina uppgifter genom att logga
+    in på din <a href="{{ public_url('/member') }}">Stockholm Makerspace medlemssida</a>.
+</p>
+
+<p>Med vänliga hälsningar,<br />Stockholm Makerspace</p>
+{% endblock %}
+
+{% block english %}
+<p>
+    Your personal information has been updated. If this was incorrect you should have a look at your personal
+    information by logging in to your <a href="{{ public_url('/member') }}">Stockholm Makerspace medlemssida</a>.
+</p>
+
+<p>Sincerely,<br />Stockholm Makerspace</p>
+{% endblock %}

--- a/api/src/templates/updated_member_info.body.html
+++ b/api/src/templates/updated_member_info.body.html
@@ -4,8 +4,7 @@
 <p>Hej {{ member.firstname }},</p>
 <p>(See below for English).</p>
 <p>
-    Dina personliga uppgifter har uppdaterats. Om detta inte var korrekt bör du se över dina uppgifter genom att logga
-    in på din <a href="{{ public_url('/member') }}">Stockholm Makerspace medlemssida</a>.
+    Dina personliga uppgifter har uppdaterats. Om detta inte var korrekt bör du kontakta styrelsen på info@makerspace.se.
 </p>
 
 {% if message_swe %}
@@ -17,8 +16,7 @@
 
 {% block english %}
 <p>
-    Your personal information has been updated. If this was incorrect you should have a look at your personal
-    information by logging in to your <a href="{{ public_url('/member') }}">Stockholm Makerspace medlemssida</a>.
+    Your personal information has been updated. If this was incorrect you should inform the board on info@makerspace.se.
 </p>
 
 {% if message_en %}

--- a/api/src/templates/updated_member_info.subject.html
+++ b/api/src/templates/updated_member_info.subject.html
@@ -1,0 +1,1 @@
+Personal information updated


### PR DESCRIPTION
- Send email when admin change member information
- Check if email contains @ and . before allowed to save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a feature to send emails to members with updates on their personal information.
  - Added a new method to handle member info updates within the app.

- **Improvements**
  - Enhanced the email validation process to include additional checks for format correctness.

- **Bug Fixes**
  - Fixed form submission to validate email before saving member data.

- **Permissions**
  - Added a new permission level for editing member information.

- **User Interface**
  - Improved form legibility with better spacing around icons and elements.

- **Documentation**
  - Updated email templates for notifying members about personal information updates in multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->