### PR TITLE
Remove deprecated docker compose V1 install method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 pip
-docker-compose
 -r api/requirements.txt


### PR DESCRIPTION
Docker compose V2 is nowadays included when installing docker, so there is no need to install this package anymore. This package does also not work for Python 3.11+ since it depends on PyYaml 5.4.1 (which does not build).