### PR TITLE
Add code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Make sure we don't get unintentional changes unless the packages.json and
+# package-lock.json files are changed synchronously
+admin/packages.json @makerspace/makeradmin
+admin/package-lock.json @makerspace/makeradmin
+public/packages.json @makerspace/makeradmin
+public/package-lock.json @makerspace/makeradmin


### PR DESCRIPTION
This is supposed to make it harder to unintentionally updating the npm package specification files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Established code ownership for package management files to enhance synchronization and prevent unintentional changes, with the `makeradmin` team responsible for oversight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->