### PR TITLE
Render the actual error

### DIFF
--- a/public/package-lock.json
+++ b/public/package-lock.json
@@ -17,6 +17,7 @@
                 "markdown-it": "^12.2.0",
                 "npm": "^9.2.0",
                 "preact": "^10.15.1",
+                "preact-render-to-string": "^6.3.1",
                 "react-calendly": "^4.1.1"
             },
             "devDependencies": {
@@ -5944,6 +5945,22 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
             }
+        },
+        "node_modules/preact-render-to-string": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.3.1.tgz",
+            "integrity": "sha512-NQ28WrjLtWY6lKDlTxnFpKHZdpjfF+oE6V4tZ0rTrunHrtZp6Dm0oFrcJalt/5PNeqJz4j1DuZDS0Y6rCBoqDA==",
+            "dependencies": {
+                "pretty-format": "^3.8.0"
+            },
+            "peerDependencies": {
+                "preact": ">=10"
+            }
+        },
+        "node_modules/pretty-format": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+            "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",

--- a/public/package.json
+++ b/public/package.json
@@ -25,6 +25,7 @@
         "markdown-it": "^12.2.0",
         "npm": "^9.2.0",
         "preact": "^10.15.1",
+        "preact-render-to-string": "^6.3.1",
         "react-calendly": "^4.1.1"
     },
     "scripts": {

--- a/public/ts/member.tsx
+++ b/public/ts/member.tsx
@@ -1,17 +1,17 @@
-import * as common from "./common";
-import * as login from "./login";
-import { UNAUTHORIZED, get_error } from "./common";
-import { JSX } from "preact/jsx-runtime";
-import { LoadCurrentAccessInfo, LoadCurrentMemberGroups, LoadCurrentMemberInfo, LoadCurrentMembershipInfo, access_t, date_t, member_t, membership_t } from "./member_common";
 import { render } from "preact";
 import { render as jsx_to_string } from "preact-render-to-string";
 import { useEffect, useMemo, useState } from "preact/hooks";
-import { show_phone_number_dialog } from "./change_phone";
-import { SubscriptionInfo, SubscriptionType, activateSubscription, cancelSubscription, getCurrentSubscriptions } from "./subscriptions";
-import { useTranslation, translateUnit, Translator } from "./translations";
-import { Sidebar } from "./sidebar";
-import { FindWellKnownProduct, LoadProductData, Product, ProductData, RelevantProducts, extractRelevantProducts, initializeStripe } from "./payment_common";
+import { JSX } from "preact/jsx-runtime";
 import Cart, { useCart } from "./cart";
+import { show_phone_number_dialog } from "./change_phone";
+import * as common from "./common";
+import { UNAUTHORIZED, get_error } from "./common";
+import * as login from "./login";
+import { LoadCurrentAccessInfo, LoadCurrentMemberGroups, LoadCurrentMemberInfo, LoadCurrentMembershipInfo, access_t, date_t, member_t, membership_t } from "./member_common";
+import { FindWellKnownProduct, LoadProductData, Product, ProductData, RelevantProducts, extractRelevantProducts, initializeStripe } from "./payment_common";
+import { Sidebar } from "./sidebar";
+import { SubscriptionInfo, SubscriptionType, activateSubscription, cancelSubscription, getCurrentSubscriptions } from "./subscriptions";
+import { Translator, translateUnit, useTranslation } from "./translations";
 import { URL_CALENDAR, URL_MEMBERBOOTH } from "./urls";
 declare var UIkit: any;
 

--- a/public/ts/member.tsx
+++ b/public/ts/member.tsx
@@ -4,6 +4,7 @@ import { UNAUTHORIZED, get_error } from "./common";
 import { JSX } from "preact/jsx-runtime";
 import { LoadCurrentAccessInfo, LoadCurrentMemberGroups, LoadCurrentMemberInfo, LoadCurrentMembershipInfo, access_t, date_t, member_t, membership_t } from "./member_common";
 import { render } from "preact";
+import { render as jsx_to_string } from "preact-render-to-string";
 import { useEffect, useMemo, useState } from "preact/hooks";
 import { show_phone_number_dialog } from "./change_phone";
 import { SubscriptionInfo, SubscriptionType, activateSubscription, cancelSubscription, getCurrentSubscriptions } from "./subscriptions";
@@ -571,7 +572,10 @@ common.documentLoaded().then(() => {
             login.render_login(root, null, null);
         } else {
             console.log(e);
-            UIkit.modal.alert("<h2>Failed to load member info</h2>");
+            UIkit.modal.alert(jsx_to_string(<>
+                <h2>Failed to load member info</h2>
+                <p>{e.toString()}</p>
+            </>));
         }
     });
 });


### PR DESCRIPTION
Instead of just showing "Error: Could not load member info", now it actually shows what the error is, like if the Stripe products have not been set up.

For example, when not having set up the Stripe products:

![image](https://github.com/makerspace/makeradmin/assets/7572427/9061bced-6b74-4072-a41e-69a40b6ed12a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved import organization for better code readability.
  - Enhanced error handling within the document load process.

- **Style**
  - Adjusted code structure for consistency.

- **Documentation**
  - Updated the summary section for clarity on recent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->