### PR TITLE
Description accounts cost centers

### DIFF
--- a/admin/src/Sales/AccountingProduct.js
+++ b/admin/src/Sales/AccountingProduct.js
@@ -408,7 +408,9 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_account}
                             value={selectedOption_account}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) => g.account}
+                            getOptionLabel={(g) =>
+                                g.account + " : " + g.description
+                            }
                             onChange={(account) =>
                                 this.selectOptionAccount(account)
                             }
@@ -424,7 +426,9 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_cost_center}
                             value={selectedOption_cost_center}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) => g.cost_center}
+                            getOptionLabel={(g) =>
+                                g.cost_center + " : " + g.description
+                            }
                             onChange={(cost_center) =>
                                 this.selectOptionCostCenter(cost_center)
                             }

--- a/admin/src/Sales/AccountingProduct.js
+++ b/admin/src/Sales/AccountingProduct.js
@@ -408,9 +408,7 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_account}
                             value={selectedOption_account}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) =>
-                                g.account + " : " + g.description
-                            }
+                            getOptionLabel={(g) => g.account}
                             onChange={(account) =>
                                 this.selectOptionAccount(account)
                             }
@@ -426,9 +424,7 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_cost_center}
                             value={selectedOption_cost_center}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) =>
-                                g.cost_center + " : " + g.description
-                            }
+                            getOptionLabel={(g) => g.cost_center}
                             onChange={(cost_center) =>
                                 this.selectOptionCostCenter(cost_center)
                             }

--- a/admin/src/Sales/AccountingProduct.js
+++ b/admin/src/Sales/AccountingProduct.js
@@ -23,9 +23,13 @@ const filterOptions_cost_center = (items_cost_center, options_cost_center) => {
 };
 
 const updateOptions_account = (options_account) => (prevState) => {
-    let options = [{ account: "No modification", id: 0 }].concat(
-        filterOptions_account(prevState.items_account, options_account),
-    );
+    let options = [
+        {
+            account: "No modification",
+            id: 0,
+            description: "Do not change account",
+        },
+    ].concat(filterOptions_account(prevState.items_account, options_account));
     return {
         showOptions_account: options,
         options_account,
@@ -33,7 +37,13 @@ const updateOptions_account = (options_account) => (prevState) => {
 };
 
 const updateOptions_cost_center = (options_cost_center) => (prevState) => {
-    let options = [{ cost_center: "No modification", id: 0 }].concat(
+    let options = [
+        {
+            cost_center: "No modification",
+            id: 0,
+            description: "Do not change cost center",
+        },
+    ].concat(
         filterOptions_cost_center(
             prevState.items_cost_center,
             options_cost_center,


### PR DESCRIPTION
Solves issue #441 .
Adds description for each account and cost center in the drop down selection lists in the product accounting page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
	- Updated the display of account and cost center options to include descriptions for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->