### PR TITLE
No multilined input fields

### DIFF
--- a/admin/src/Sales/AccountingAccount.js
+++ b/admin/src/Sales/AccountingAccount.js
@@ -1,11 +1,10 @@
 import React from "react";
-import Collection from "../Models/Collection";
 import CollectionTable from "../Components/CollectionTable";
-import CollectionNavigation from "../Models/CollectionNavigation";
-import TextInput from "../Components/TextInput";
-import TransactionAccount from "../Models/TransactionAccount";
 import SearchBox from "../Components/SearchBox";
-import Textarea from "../Components/Textarea";
+import TextInput from "../Components/TextInput";
+import Collection from "../Models/Collection";
+import CollectionNavigation from "../Models/CollectionNavigation";
+import TransactionAccount from "../Models/TransactionAccount";
 
 class AccountingAccount extends CollectionNavigation {
     constructor(props) {
@@ -63,7 +62,7 @@ class AccountingAccount extends CollectionNavigation {
                             title="Namn"
                             placeholder="Nummer på nytt konto"
                         />
-                        <Textarea
+                        <TextInput
                             model={this.transactionAccount}
                             name="description"
                             title="Beskrivning"

--- a/admin/src/Sales/AccountingCostCenter.js
+++ b/admin/src/Sales/AccountingCostCenter.js
@@ -1,11 +1,10 @@
 import React from "react";
-import Collection from "../Models/Collection";
 import CollectionTable from "../Components/CollectionTable";
-import CollectionNavigation from "../Models/CollectionNavigation";
-import TextInput from "../Components/TextInput";
-import TransactionCostCenter from "../Models/TransactionCostCenter";
 import SearchBox from "../Components/SearchBox";
-import Textarea from "../Components/Textarea";
+import TextInput from "../Components/TextInput";
+import Collection from "../Models/Collection";
+import CollectionNavigation from "../Models/CollectionNavigation";
+import TransactionCostCenter from "../Models/TransactionCostCenter";
 
 class AccountingCostCenter extends CollectionNavigation {
     constructor(props) {
@@ -66,7 +65,7 @@ class AccountingCostCenter extends CollectionNavigation {
                             title="Namn"
                             placeholder="Namn på nytt kostnadsställe"
                         />
-                        <Textarea
+                        <TextInput
                             model={this.transactionCostCenter}
                             name="description"
                             title="Beskrivning"

--- a/admin/src/Sales/AccountingProduct.js
+++ b/admin/src/Sales/AccountingProduct.js
@@ -408,7 +408,9 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_account}
                             value={selectedOption_account}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) => g.account}
+                            getOptionLabel={(g) =>
+                                g.account + " : " + g.description
+                            }
                             onChange={(account) =>
                                 this.selectOptionAccount(account)
                             }
@@ -424,7 +426,9 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_cost_center}
                             value={selectedOption_cost_center}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) => g.cost_center}
+                            getOptionLabel={(g) =>
+                                g.cost_center + " : " + g.description
+                            }
                             onChange={(cost_center) =>
                                 this.selectOptionCostCenter(cost_center)
                             }

--- a/admin/src/Sales/AccountingProduct.js
+++ b/admin/src/Sales/AccountingProduct.js
@@ -408,9 +408,7 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_account}
                             value={selectedOption_account}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) =>
-                                g.account + " : " + g.description
-                            }
+                            getOptionLabel={(g) => g.account}
                             onChange={(account) =>
                                 this.selectOptionAccount(account)
                             }
@@ -426,9 +424,7 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_cost_center}
                             value={selectedOption_cost_center}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) =>
-                                g.cost_center + " : " + g.description
-                            }
+                            getOptionLabel={(g) => g.cost_center}
                             onChange={(cost_center) =>
                                 this.selectOptionCostCenter(cost_center)
                             }


### PR DESCRIPTION
Remove ability to add multiple lines in description when adding new accounts and cost centers.

Fixes issue #440 . For me there doesn't seem to be any additional fields in the accounting page with this problem, since the others have default to only allow one line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated input fields from multi-line text areas to single-line text inputs in the sales accounting sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->