### PR TITLE
Scrollable product list accounting

### DIFF
--- a/admin/dist/css/uikit.almost-flat.css
+++ b/admin/dist/css/uikit.almost-flat.css
@@ -8412,6 +8412,13 @@ a.uk-thumbnail:focus {
 /* Scrollable
  ========================================================================== */
 /*
+ * Enable scrolling for component
+ */
+.uk-scrollable-component {
+  max-height: 300px;
+  overflow-y: auto;
+}
+ /*
  * Enable scrolling for preformatted text
  */
 .uk-scrollable-text {

--- a/admin/dist/css/uikit.almost-flat.css
+++ b/admin/dist/css/uikit.almost-flat.css
@@ -8412,10 +8412,10 @@ a.uk-thumbnail:focus {
 /* Scrollable
  ========================================================================== */
 /*
- * Enable scrolling for component
+ * Enable scrolling for table
  */
-.uk-scrollable-component {
-  max-height: 300px;
+.uk-scrollable-table {
+  max-height: 600px;
   overflow-y: auto;
 }
  /*

--- a/admin/src/Sales/AccountingProduct.js
+++ b/admin/src/Sales/AccountingProduct.js
@@ -408,7 +408,9 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_account}
                             value={selectedOption_account}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) => g.account}
+                            getOptionLabel={(g) =>
+                                g.account + " : " + g.description
+                            }
                             onChange={(account) =>
                                 this.selectOptionAccount(account)
                             }
@@ -424,7 +426,9 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_cost_center}
                             value={selectedOption_cost_center}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) => g.cost_center}
+                            getOptionLabel={(g) =>
+                                g.cost_center + " : " + g.description
+                            }
                             onChange={(cost_center) =>
                                 this.selectOptionCostCenter(cost_center)
                             }

--- a/admin/src/Sales/AccountingProduct.js
+++ b/admin/src/Sales/AccountingProduct.js
@@ -444,7 +444,7 @@ class AccountingProduct extends CollectionNavigation {
 
                     <CollectionTable
                         id="product_table"
-                        className="uk-margin-top prevent-select uk-scrollable-component"
+                        className="uk-margin-top prevent-select uk-scrollable-table"
                         collection={this.collection}
                         emptyMessage="Inga produkter"
                         columns={[

--- a/admin/src/Sales/AccountingProduct.js
+++ b/admin/src/Sales/AccountingProduct.js
@@ -444,7 +444,7 @@ class AccountingProduct extends CollectionNavigation {
 
                     <CollectionTable
                         id="product_table"
-                        className="uk-margin-top prevent-select"
+                        className="uk-margin-top prevent-select uk-scrollable-component"
                         collection={this.collection}
                         emptyMessage="Inga produkter"
                         columns={[

--- a/admin/src/Sales/AccountingProduct.js
+++ b/admin/src/Sales/AccountingProduct.js
@@ -408,9 +408,7 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_account}
                             value={selectedOption_account}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) =>
-                                g.account + " : " + g.description
-                            }
+                            getOptionLabel={(g) => g.account}
                             onChange={(account) =>
                                 this.selectOptionAccount(account)
                             }
@@ -426,9 +424,7 @@ class AccountingProduct extends CollectionNavigation {
                             options={showOptions_cost_center}
                             value={selectedOption_cost_center}
                             getOptionValue={(g) => g.id}
-                            getOptionLabel={(g) =>
-                                g.cost_center + " : " + g.description
-                            }
+                            getOptionLabel={(g) => g.cost_center}
                             onChange={(cost_center) =>
                                 this.selectOptionCostCenter(cost_center)
                             }


### PR DESCRIPTION
Solves issue #439, list of products in the accounting page has a separate scroll to keep the header fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced scrollable tables to enhance the user interface for large datasets or limited display areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->