### PR TITLE
(Quick)fix test_subscriptions_late_signed_agreement_february

### DIFF
--- a/api/src/shop/test/subscriptions_test.py
+++ b/api/src/shop/test/subscriptions_test.py
@@ -836,6 +836,10 @@ class Test(FlaskTestBase):
         assert summary.labaccess_active
         assert summary.labaccess_end == sub_start + time_delta(days=61)
 
+        # FIXME: For some reason we need to advance the clock twice here to get
+        # all the events needed. The polling function called when clock is advanced
+        # should be refactored to fix it.
+        self.advance_clock(clock, noon(sub_start + time_delta(months=2, days=3)))
         self.advance_clock(clock, noon(sub_start + time_delta(months=2, days=3)))
 
         # The member should now have finished their binding period and been billed for another month


### PR DESCRIPTION
Quick fix for a testcase, before the polling is fixed more thoroughly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the event handling in subscription services by refining the clock advancement logic during tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->