### PR TITLE
Fix stripe intents test case

### DIFF
--- a/api/src/shop/stripe_payment_intent.py
+++ b/api/src/shop/stripe_payment_intent.py
@@ -206,8 +206,8 @@ def pay_with_stripe(transaction: Transaction, payment_method_id: str, setup_futu
 def get_stripe_payment_intents(start_date: datetime, end_date: datetime) -> List[stripe.PaymentIntent]:
     expand = ["data.latest_charge.balance_transaction"]
     created = {
-        "gte": int(mktime(start_date.astimezone(pytz.UTC).timetuple())),
-        "lt": int(mktime(end_date.astimezone(pytz.UTC).timetuple())),
+        "gte": int(start_date.astimezone(pytz.UTC).timestamp()),
+        "lt": int(end_date.astimezone(pytz.UTC).timestamp()),
     }
     logger.info(f"Fetching stripe payment intents from {start_date} ({created['gte']}) to {end_date} ({created['lt']})")
 

--- a/api/src/shop/test/stripe_payment_intent_test.py
+++ b/api/src/shop/test/stripe_payment_intent_test.py
@@ -302,18 +302,8 @@ class StripePaymentIntentTest(FlaskTestBase):
         )
         test_intents_out_of_range.append(stripe_intent.id)
 
-        created = {
-            "gte": int(start.timestamp()),
-            "lt": int(end.timestamp()),
-        }
-        stripe_intents = retry(
-            lambda: stripe.PaymentIntent.list(
-                limit=5,
-                created=created,
-                expand=["data.latest_charge.balance_transaction"],
-            )
-        )
-        filtered_intents = self.filter_intents_on_customers([intent for intent in stripe_intents.auto_paging_iter()])
+        intents = get_stripe_payment_intents(start, end)
+        filtered_intents = self.filter_intents_on_customers(intents)
 
         assert len(filtered_intents) == len(test_intents_in_range)
         for intent in filtered_intents.values():

--- a/api/src/shop/test/stripe_payment_intent_test.py
+++ b/api/src/shop/test/stripe_payment_intent_test.py
@@ -302,8 +302,18 @@ class StripePaymentIntentTest(FlaskTestBase):
         )
         test_intents_out_of_range.append(stripe_intent.id)
 
-        intents = get_stripe_payment_intents(start, end)
-        filtered_intents = self.filter_intents_on_customers(intents)
+        created = {
+            "gte": int(start.timestamp()),
+            "lt": int(end.timestamp()),
+        }
+        stripe_intents = retry(
+            lambda: stripe.PaymentIntent.list(
+                limit=5,
+                created=created,
+                expand=["data.latest_charge.balance_transaction"],
+            )
+        )
+        filtered_intents = self.filter_intents_on_customers([intent for intent in stripe_intents.auto_paging_iter()])
 
         assert len(filtered_intents) == len(test_intents_in_range)
         for intent in filtered_intents.values():


### PR DESCRIPTION
Testcase didn't work because it called a function that converted timestamp from UTC to local TZ, so it missed the payment intents created during the test run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
  - Updated the method for fetching payment intents in tests to use a specific date range criteria.
- **Refactor**
  - Enhanced date handling for improved accuracy in fetching payment intents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->