### PR TITLE
Simplify the README a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,36 +184,18 @@ These subscriptions will automatically be turned into makeradmin products so tha
 
 Note: You should _not_ modify these products in makeradmin. They will be reset whenever the docker container restarts anyway (when the registration page is visited).
 
-#### Needed Stripe configuration
+#### Required Stripe configuration
 
-The configuration needed on stripe is:
-
--   Create a **product** for base membership. Add the metadata "subscription_type"="membership" to the **product** item
-    -   Add a yearly **price**, and add the metadata "price_type"="recurring" to the **price** item
--   Create a **product** for makerspace access. Add the metadata "subscription_type"="labaccess" to the **product** item
-    -   Add a monthly price, and add the metadata "price_type"="recurring" to the **price** item
-    -   Add a **price** for N months, where N is the binding period as specified in `stripe_subscriptions.py->BINDING_PERIOD`. The price should be N times the recurring price. Add the metadata "price_type"="binding_period"
--   Create a **coupon** for low income discount. It should be with percentage discount. Add the metadata "makerspace_price_level" = "low_income_discount"
-
-You can achieve all of this using the Stripe CLI:
+Run the following script to create the required Stripe products. _You should only run it once._ But if anything goes wrong, you can modify the products from the Stripe dashboard.
 
 ```bash
-# Create a yearly membership product with a price
-stripe products create -d 'metadata[subscription_type]=membership' --name='Base membership'
-# -> This gives a product ID `prod_MEMBERSHIP` that you need to substitute below
-stripe prices create --unit-amount=20000 --currency=sek -d "recurring[interval]"=year --product="prod_MEMBERSHIP" -d "recurring[interval_count]"=1 -d 'metadata[price_type]=recurring'
-
-# Create a makerspace access product with prices
-stripe products create -d 'metadata[subscription_type]=labaccess' --name='Makerspace access'
-# -> This gives a product ID `prod_LABACCESS` that you need to substitute below
-stripe prices create --unit-amount=30000 --currency=sek -d "recurring[interval]"=month --product="prod_LABACCESS" -d "recurring[interval_count]"=1 -d 'metadata[price_type]=recurring'
-stripe prices create --unit-amount=60000 --currency=sek -d "recurring[interval]"=month --product="prod_LABACCESS" -d "recurring[interval_count]"=2 -d 'metadata[price_type]=binding_period'
-
-# Create a coupon
-stripe coupons create --name='Low income discount' --percent-off=50 -d 'metadata[makerspace_price_level]=low_income_discount'
+# Print the help
+./create_stripe_products.py --help
+# Example usage (change the arguments to suit your needs)
+./create_stripe_products.py --yearly-price 200 --monthly-price 300 --binding-period 2
 ```
 
-If you try to access any page which needs these products (e.g. the registration page, or the member page), makeradmin will fetch them from stripe and do a bunch of validation checks.
+If you try to access any page which needs these products (e.g. the registration page, or the member page), makeradmin will fetch them from stripe and do a bunch of validation checks on them.
 
 ### Setting up required products in makeradmin
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you for some reason want to remove the existing database and start from scrat
 make clean-nuke
 ```
 
-_Warning: this will completely wipe out all your makeradmin data!_
+⚠️ _Warning: this will completely wipe out all your makeradmin data!_
 
 After this you can run `make firstrun` again to set things up again.
 

--- a/create_stripe_products.py
+++ b/create_stripe_products.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+
+import stripe
+from dotenv import dotenv_values
+
+env = dotenv_values()
+stripe.api_key = env.get("STRIPE_PRIVATE_KEY")
+currency = env.get("CURRENCY")
+
+
+def to_stripe_currency(price: float) -> int:
+    return int(price * 100)
+
+
+parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+parser.add_argument(
+    "--yearly-price",
+    metavar="PRICE",
+    default=200,
+    type=float,
+    help="The price for base membership. Paid each year",
+)
+parser.add_argument(
+    "--monthly-price",
+    metavar="PRICE",
+    default=300,
+    type=float,
+    help="The price for Makerspace access. Paid each month",
+)
+parser.add_argument(
+    "--binding-period",
+    metavar="MONTHS",
+    default=2,
+    type=int,
+    help="The binding period in months.",
+)
+args = parser.parse_args()
+
+
+yearly_price = args.yearly_price
+monthly_price = args.monthly_price
+binding_period_in_months = args.binding_period
+
+exit(0)
+
+
+base_membership = stripe.Product.create(
+    name="Base membership",
+    description="The base membership to the association",
+    metadata={"subscription_type": "membership"},
+)
+
+price_yearly = stripe.Price.create(
+    unit_amount=to_stripe_currency(yearly_price),
+    currency=currency,
+    recurring={"interval": "year", "interval_count": 1},
+    product=base_membership["id"],
+    metadata={"price_type": "recurring"},
+)
+
+makerspace_access = stripe.Product.create(
+    name="Makerspace access",
+    description="The base membership to the association",
+    metadata={"subscription_type": "labaccess"},
+)
+
+price_subscription = stripe.Price.create(
+    unit_amount=to_stripe_currency(monthly_price),
+    currency=currency,
+    recurring={"interval": "month", "interval_count": 1},
+    product=makerspace_access["id"],
+    metadata={"price_type": "recurring"},
+)
+
+price_binding_period = stripe.Price.create(
+    unit_amount=to_stripe_currency(monthly_price * binding_period_in_months),
+    currency=currency,
+    recurring={"interval": "month", "interval_count": binding_period_in_months},
+    product=makerspace_access["id"],
+    metadata={"price_type": "binding_period"},
+)
+
+print(f"Base membership ID: {base_membership.id}")
+print(f"- price ID: {price_yearly.id}")
+print(f"Makerspace access ID: {makerspace_access.id}")
+print(f"-   subscription price ID: {price_subscription.id}")
+print(f"- binding period price ID: {price_binding_period.id}")


### PR DESCRIPTION
Move the one-time configuration to a Python script.

That way you don't need to neither go to the Stripe page and create the products manually, nor copy-paste the script from the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the section title to "Required Stripe configuration" and included a script for automatic Stripe product setup in the README.

- **New Features**
	- Implemented a script to automatically create Stripe products and prices for memberships and makerspace access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->