### PR TITLE
Fix key error in quiz statistics if no one has done any quizes

### DIFF
--- a/api/src/quiz/views.py
+++ b/api/src/quiz/views.py
@@ -163,7 +163,7 @@ def member_quiz_statistics(member_id: int):
     return [
         {
             "quiz": quiz_entity.to_obj(quiz),
-            "total_questions_in_quiz": total_questions_in_quiz[quiz.id],
+            "total_questions_in_quiz": total_questions_in_quiz[quiz.id] if quiz.id in total_questions_in_quiz else 0,
             "correctly_answered_questions": answered_questions_per_quiz[quiz.id]
             if quiz.id in answered_questions_per_quiz
             else 0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in quiz statistics to default to 0 when quiz data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->