### PR TITLE
Clarify that user name is member number or email on login page

### DIFF
--- a/admin/src/Components/Login.jsx
+++ b/admin/src/Components/Login.jsx
@@ -10,7 +10,7 @@ export default class Login extends React.Component {
         const password = this.password.value;
 
         if (!username || !password) {
-            showError("Du måste fylla i användarnamn och lösenord");
+            showError("Du måste fylla i email/medlemsnummer och lösenord");
             return;
         }
 
@@ -41,7 +41,7 @@ export default class Login extends React.Component {
                                     }}
                                     className="uk-form-large uk-form-width-large"
                                     type="text"
-                                    placeholder="Användarnamn"
+                                    placeholder="Email/Medlemsnummer"
                                 />
                             </div>
                         </div>

--- a/admin/src/Components/RequestPasswordReset.jsx
+++ b/admin/src/Components/RequestPasswordReset.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import auth from "../auth";
 import { withRouter } from "react-router";
+import auth from "../auth";
 import { browserHistory } from "../browser_history";
 import { showError, showSuccess } from "../message";
 
@@ -46,9 +46,9 @@ class RequestPasswordReset extends React.Component {
 
                             <div className="uk-form-row">
                                 <p>
-                                    Fyll i ditt användarnamn så skickar vi
-                                    instruktioner om hur du nollställer ditt
-                                    lösenord.
+                                    Fyll i ditt email eller medlemsnummer så
+                                    skickar vi instruktioner om hur du
+                                    nollställer ditt lösenord.
                                 </p>
                             </div>
 
@@ -61,7 +61,7 @@ class RequestPasswordReset extends React.Component {
                                         }}
                                         className="uk-form-large uk-form-width-large"
                                         type="text"
-                                        placeholder="Användarnamn"
+                                        placeholder="Email/Medlemsnummer"
                                     />
                                 </div>
                             </div>

--- a/admin/src/auth.js
+++ b/admin/src/auth.js
@@ -57,7 +57,7 @@ class Auth {
             .then((response) => {
                 if (response.status === 401) {
                     return Promise.reject(
-                        "Felaktigt användarnamn eller lösenord.",
+                        "Felaktig email/medlemsnummer eller lösenord.",
                     );
                 }
                 if (response.status === 429) {

--- a/public/ts/login.tsx
+++ b/public/ts/login.tsx
@@ -29,7 +29,9 @@ export function login_via_password(
         })
         .catch((response: ServerResponse<any>) => {
             if (response.status === common.UNAUTHORIZED) {
-                return Promise.reject("Felaktigt användarnamn eller lösenord.");
+                return Promise.reject(
+                    "Felaktig email/medlemsnummer eller lösenord.",
+                );
             }
 
             return Promise.reject(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error messages and input placeholders in login and password reset components to prompt for "Email/Medlemsnummer" instead of "Användarnamn," enhancing clarity for users during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->