### PR TITLE
Fix a docker warning by removing version from docker files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   db2:
     ports:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   api:
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   db2:
     volumes:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   db2:
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   db2:
     image: mysql:8.0.33


### PR DESCRIPTION
Docker version later than 2.25 warns about version being obsolete. We probably need to update the docker version on the server before deploying this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated Docker Compose configurations across different environments.
- **Style**
  - Improved indentation for better readability in Docker Compose files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->