### PR TITLE
Change products to store stripe product id instead of setting the stripe product id directly

### DIFF
--- a/api/src/migrations/0027_stripe_product_id_connection.sql
+++ b/api/src/migrations/0027_stripe_product_id_connection.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `webshop_products` ADD COLUMN `stripe_product_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;

--- a/api/src/shop/models.py
+++ b/api/src/shop/models.py
@@ -72,6 +72,7 @@ class Product(Base):
     updated_at = Column(DateTime, server_default=func.now())
     deleted_at = Column(DateTime)
     show = Column(Boolean, nullable=False, server_default="1")
+    stripe_product_id = Column(String(64))
 
     category = relationship(ProductCategory, backref="products")
     actions = relationship("ProductAction")

--- a/api/src/shop/stripe_product_price.py
+++ b/api/src/shop/stripe_product_price.py
@@ -95,7 +95,7 @@ def eq_makeradmin_stripe_price(makeradmin_product: Product, stripe_price: stripe
 
     recurring = makeradmin_to_stripe_recurring(makeradmin_product, price_type)
 
-    if 
+    if (
         stripe_price.unit_amount != stripe_amount_from_makeradmin_product(makeradmin_product, recurring)
         or stripe_price.currency != CURRENCY
         or stripe_price.metadata.get("price_type") != price_type.value
@@ -107,7 +107,8 @@ def eq_makeradmin_stripe_price(makeradmin_product: Product, stripe_price: stripe
         return False
 
     if recurring is not None:
-        return (stripe_price.recurring.get("interval") == recurring.interval
+        return (
+            stripe_price.recurring.get("interval") == recurring.interval
             and stripe_price.recurring.get("interval_count") == recurring.interval_count
         )
 

--- a/api/src/shop/stripe_product_price.py
+++ b/api/src/shop/stripe_product_price.py
@@ -1,14 +1,14 @@
 from dataclasses import asdict, dataclass
 from logging import getLogger
-from typing import Any, Callable, Dict, List, Tuple, TypeVar
+from typing import Any, Dict, List, Tuple
 
 import stripe
-from service.config import debug_mode
 from service.error import InternalServerError
 
 from shop.models import Product
 from shop.stripe_constants import (
     CURRENCY,
+    MakerspaceMetadataKeys,
     PriceType,
 )
 from shop.stripe_util import StripeRecurring, get_subscription_category, retry, stripe_amount_from_makeradmin_product
@@ -24,7 +24,10 @@ makeradmin_unit_to_stripe_unit = {
 
 
 def makeradmin_to_stripe_recurring(makeradmin_product: Product, price_type: PriceType) -> StripeRecurring | None:
+    subscription_category_id = get_subscription_category().id
     if price_type == PriceType.RECURRING or price_type == PriceType.BINDING_PERIOD:
+        if makeradmin_product.category.id != subscription_category_id:
+            raise ValueError(f"Unexpected price type {price_type} for non-subscription product {makeradmin_product.id}")
         if makeradmin_product.unit in makeradmin_unit_to_stripe_unit:
             interval = makeradmin_unit_to_stripe_unit[makeradmin_product.unit]
         else:
@@ -32,17 +35,17 @@ def makeradmin_to_stripe_recurring(makeradmin_product: Product, price_type: Pric
         interval_count = makeradmin_product.smallest_multiple if price_type == PriceType.BINDING_PERIOD else 1
         return StripeRecurring(interval=interval, interval_count=interval_count)
     else:
+        if makeradmin_product.category.id == subscription_category_id:
+            raise ValueError(f"Unexpected price type {price_type} for subscription product {makeradmin_product.id}")
         return None
 
 
 def get_stripe_product_id(makeradmin_product: Product) -> str:
-    prefix = "debug" if debug_mode() else "prod"
-    return f"{prefix}_{makeradmin_product.id}"
+    return f"{makeradmin_product.id}"
 
 
 def get_stripe_price_lookup_key(makeradmin_product: Product, price_type: PriceType) -> str:
-    prefix = "debug" if debug_mode() else "prod"
-    return f"{prefix}_{makeradmin_product.id}_{price_type.value}"
+    return f"{makeradmin_product.id}_{price_type.value}"
 
 
 def get_stripe_product(makeradmin_product: Product) -> stripe.Product | None:
@@ -68,19 +71,32 @@ def get_stripe_prices(
 
 def eq_makeradmin_stripe_product(makeradmin_product: Product, stripe_product: stripe.Product) -> bool:
     """Check that the essential parts of the product are the same in both makeradmin and stripe"""
+    if stripe_product.id != str(makeradmin_product.id):
+        raise ValueError(
+            f"Stripe product id {stripe_product.id} and makeradmin product id {makeradmin_product.id} does not match"
+        )
     return stripe_product.name == makeradmin_product.name
 
 
 def eq_makeradmin_stripe_price(makeradmin_product: Product, stripe_price: stripe.Price, price_type: PriceType) -> bool:
     """Check that the essential parts of the price are the same in both makeradmin and stripe"""
+    lookup_key_for_product = get_stripe_price_lookup_key(makeradmin_product, price_type)
+    if stripe_price.lookup_key != lookup_key_for_product:
+        raise ValueError(
+            f"Stripe price lookup key {stripe_price.lookup_key} and corresponding key from makeradmin product {makeradmin_product.id} and PriceType {price_type} does not match"
+        )
+
     recurring = makeradmin_to_stripe_recurring(makeradmin_product, price_type)
     different = []
 
-    if recurring:
+    if recurring is not None:
         if stripe_price.recurring is None:
             return False
         different.append(stripe_price.recurring.get("interval") != recurring.interval)
         different.append(stripe_price.recurring.get("interval_count") != recurring.interval_count)
+    else:
+        if stripe_price.recurring is not None:
+            return False
     different.append(stripe_price.unit_amount != stripe_amount_from_makeradmin_product(makeradmin_product, recurring))
     different.append(stripe_price.currency != CURRENCY)
     different.append(stripe_price.metadata.get("price_type") != price_type.value)
@@ -93,7 +109,9 @@ def _create_stripe_product(makeradmin_product: Product) -> stripe.Product:
         lambda: stripe.Product.create(
             id=id,
             name=makeradmin_product.name,
-            description=f"Created by Makeradmin, product id (#{makeradmin_product.id})",
+            metadata={
+                MakerspaceMetadataKeys.PRODUCT_ID.value: makeradmin_product.id,
+            },
         )
     )
     return stripe_product
@@ -114,7 +132,10 @@ def _create_stripe_price(
             unit_amount=stripe_amount_from_makeradmin_product(makeradmin_product, recurring),
             currency=CURRENCY,
             recurring=recurring_dict,
-            metadata={"price_type": price_type.value},
+            metadata={
+                MakerspaceMetadataKeys.PRICE_TYPE.value: price_type.value,
+                MakerspaceMetadataKeys.PRODUCT_ID.value: makeradmin_product.id,
+            },
         )
     )
     return stripe_price
@@ -160,7 +181,7 @@ def get_or_create_stripe_prices_for_product(
         prices_to_create = []
         for price_type in price_types:
             stripe_price = _find_price_type(stripe_prices, price_type)
-            if stripe_price:
+            if stripe_price is not None:
                 prices_to_return[price_type] = stripe_price
             else:
                 prices_to_create.append(price_type)

--- a/api/src/shop/test/stripe_product_price_test.py
+++ b/api/src/shop/test/stripe_product_price_test.py
@@ -163,6 +163,7 @@ class StripeProductPriceTest(ShopTestMixin, FlaskTestBase):
         stripe_test_product = _create_stripe_product(makeradmin_test_product)
         assert stripe_test_product
         assert stripe_test_product.name == makeradmin_test_product.name
+        assert makeradmin_test_product.stripe_product_id == stripe_test_product.id
 
     def test_create_product_with_price_regular(self) -> None:
         makeradmin_test_product = self.db.create_product(


### PR DESCRIPTION
This PR changes the behavior for the stripe-makeradmin relationship for the products. Instead of setting the stripe product id from the makeradmin product id it stores the stripe product id in the db in the same way as we do for customers / members. This should is required if we want to use the existing stripe product and prices after merging #375 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Stripe product ID integration for webshop products to enhance payment processing capabilities.
	- Introduced new retry mechanisms for handling Stripe rate limit errors, improving the reliability of payment operations.

- **Enhancements**
	- Improved error handling and validation in Stripe product and price management functions.
	- Enhanced logic for creating and updating Stripe product prices, ensuring accurate billing and subscription management.

- **Bug Fixes**
	- Adjusted error handling strategies in Stripe operations to prevent failures during payment method updates and price replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->