### PR TITLE
Make registration flow work without 46elks set up

### DIFF
--- a/api/src/change_phone_request.py
+++ b/api/src/change_phone_request.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from random import randint
 
-from dispatch_sms import send_validation_code
+from dispatch_sms import NoAuthConfigured, send_validation_code
 from membership.models import PhoneNumberChangeRequest, normalise_phone_number
 from multiaccessy.invite import AccessyError, ensure_accessy_labaccess
 from service.db import db_session
@@ -82,8 +82,10 @@ def change_phone_request(member_id: int | None, phone: str) -> int:
         logging.info(
             f"member id {member_id} change phone number request, sms sent, phone {phone}, code {validation_code}"
         )
-    except Exception as e:
-        raise BadRequest("Misslyckades med att skicka sms med verifikations kod.")
+    except NoAuthConfigured:
+        pass
+    except Exception:
+        raise BadRequest("Misslyckades med att skicka sms med verifikations kod")
 
     change_request = PhoneNumberChangeRequest(
         member_id=member_id, phone=phone, validation_code=validation_code, completed=False, timestamp=datetime.utcnow()

--- a/api/src/dispatch_sms.py
+++ b/api/src/dispatch_sms.py
@@ -2,17 +2,21 @@ from logging import getLogger
 
 import requests
 from service.config import get_46elks_auth
-from service.error import InternalServerError, UnprocessableEntity
+from service.error import InternalServerError
 
 logger = getLogger("makeradmin")
+
+
+class NoAuthConfigured(Exception):
+    pass
 
 
 def send_sms(phone: str, message: str) -> None:
     data = {"from": "Makerspace", "to": phone, "message": message}
     auth = get_46elks_auth()
     if not auth:
-        logger.info(f"NOT sending sms, no auth configured {phone=} {data=}")
-        raise UnprocessableEntity("Cannot send SMS because the server has not been configured for it.")
+        logger.info(f"NOT sending SMS, authentication not configured {phone=} {data=}")
+        raise NoAuthConfigured("Cannot send SMS because the server has not been configured for it.")
 
     logger.info(f"sending sms {phone=} {data=}")
 


### PR DESCRIPTION
Relates to #493.

Previously you would just get the following popup when you tried to register locally but didn't have 46elks configured:
![image](https://github.com/makerspace/makeradmin/assets/7572427/ad1c59d8-2eba-497b-b2af-b6eccfacabb7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in phone number validation by introducing specific exceptions for authentication issues.
	- Updated SMS dispatching to accurately reflect authentication configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->