### PR TITLE
Validate base membership exists for lab access purchase

### DIFF
--- a/api/src/shop/transactions.py
+++ b/api/src/shop/transactions.py
@@ -342,11 +342,14 @@ def payment_success(transaction: Transaction) -> None:
 
 def process_cart(member_id: int, cart: List[CartItem]) -> Tuple[Decimal, List[TransactionContent]]:
     contents = []
+    labaccess_in_cart = False
+    base_membership_in_cart = False
 
     member = db_session.get(Member, member_id)
     if member is None:
         raise NotFound(message=f"Could not find member with id {member_id}.")
     price_level = get_price_level_for_member(member)
+    member_has_base_membership = "membership" in [span.type for span in member.spans]
 
     with localcontext() as ctx:
         ctx.clear_flags()
@@ -370,7 +373,8 @@ def process_cart(member_id: int, cart: List[CartItem]) -> Tuple[Decimal, List[Tr
                     what=NEGATIVE_ITEM_COUNT,
                 )
 
-            if product.get_metadata(MakerspaceMetadataKeys.SUBSCRIPTION_TYPE, None) is not None:
+            subscription_type = product.get_metadata(MakerspaceMetadataKeys.SUBSCRIPTION_TYPE, None)
+            if subscription_type is not None:
                 if count != product.smallest_multiple:
                     raise BadRequest(
                         f"Bad count for subscription product {product_id}. Count must be exactly {product.smallest_multiple}, was {count}.",
@@ -387,6 +391,13 @@ def process_cart(member_id: int, cart: List[CartItem]) -> Tuple[Decimal, List[Tr
             if product.filter:
                 PRODUCT_FILTERS[product.filter](item, member_id)
 
+            special_product_id = product.get_metadata(MakerspaceMetadataKeys.SPECIAL_PRODUCT_ID, None)
+            if subscription_type == SubscriptionType.LAB or special_product_id == "single_labaccess_month":
+                labaccess_in_cart = True
+
+            if subscription_type == SubscriptionType.MEMBERSHIP or special_product_id == "single_membership_year":
+                base_membership_in_cart = True
+
             discount = get_discount_for_product(product, price_level)
 
             amount = Decimal(product.price) * Decimal(count) * (1 - discount.fraction_off)
@@ -394,6 +405,11 @@ def process_cart(member_id: int, cart: List[CartItem]) -> Tuple[Decimal, List[Tr
 
             content = TransactionContent(product_id=product_id, count=count, amount=amount)
             contents.append(content)
+
+        if labaccess_in_cart and not (member_has_base_membership or base_membership_in_cart):
+            raise BadRequest(
+                "Could not purchase selected subscription. Please buy the base annual membership before lab access."
+            )
 
         if ctx.flags[Rounded]:
             # This can possibly happen with huge values, I suppose they will be caught below anyway but it's good to

--- a/api/src/shop/transactions.py
+++ b/api/src/shop/transactions.py
@@ -349,7 +349,7 @@ def process_cart(member_id: int, cart: List[CartItem]) -> Tuple[Decimal, List[Tr
     if member is None:
         raise NotFound(message=f"Could not find member with id {member_id}.")
     price_level = get_price_level_for_member(member)
-    member_has_base_membership = "membership" in [span.type for span in member.spans]
+    member_has_base_membership = Span.MEMBERSHIP in [span.type for span in member.spans]
 
     with localcontext() as ctx:
         ctx.clear_flags()

--- a/api/src/systest/api/purchase_test.py
+++ b/api/src/systest/api/purchase_test.py
@@ -94,3 +94,9 @@ class PurchaseTest(ApiShopTestMixin, ApiTest):
         )
 
         self.post(f"/webshop/pay", purchase.to_dict(), token=self.token).expect(code=400, what="empty_cart")
+
+    def test_labaccess_purchase_fails_without_base_membership(self):
+        pass
+
+    def test_labaccess_purchase_allowed_together_with_base_membership(self):
+        pass


### PR DESCRIPTION
Work in progress. Leaving placeholder for new tests to add

Fixes #179 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced cart processing logic to enforce membership requirements for lab access purchases.

- **Tests**
	- Added comprehensive test cases to validate lab access purchase scenarios, including:
		- Preventing lab access purchase without base membership
		- Allowing lab access purchase with base membership
		- Verifying lab access purchase with an active membership

<!-- end of auto-generated comment: release notes by coderabbit.ai -->