### PR TITLE
Manually install node in public.

### DIFF
--- a/public/Dockerfile
+++ b/public/Dockerfile
@@ -10,11 +10,10 @@ RUN apk update \
 	netcat-openbsd \
 	inotify-tools \
 	wget \
+	nodejs \
 	npm \
 	curl \
 	&& rm -rf /var/cache/apk/*
-
-RUN npm install -g npm@9.2.0
 
 RUN npm i -g npm sass
 


### PR DESCRIPTION
Node version 19 which is automatically installed with npm is deprecated which braks the build at the moment.
Installing the nodejs package instead installs version 18 which is LTS.

The latest LTS version of node is unavailable in the used version of alpine so a better solution should be done at some point.