### PR TITLE
Show errors on missing config

### DIFF
--- a/public/ts/licenses.tsx
+++ b/public/ts/licenses.tsx
@@ -42,7 +42,7 @@ common.documentLoaded().then(() => {
                     jsx_to_string(
                         <>
                             <h2>Failed to load member info</h2>
-                            <p>{e.toString()}</p>
+                            <pre>{JSON.stringify(e)}</pre>
                         </>,
                     ),
                 );

--- a/public/ts/licenses.tsx
+++ b/public/ts/licenses.tsx
@@ -1,4 +1,5 @@
 import { render } from "preact";
+import { render as jsx_to_string } from "preact-render-to-string";
 import * as common from "./common";
 import { UNAUTHORIZED } from "./common";
 import * as login from "./login";
@@ -37,7 +38,14 @@ common.documentLoaded().then(() => {
                 // Render login
                 login.render_login(root, null, null);
             } else {
-                UIkit.modal.alert("<h2>Failed to load member info</h2>");
+                UIkit.modal.alert(
+                    jsx_to_string(
+                        <>
+                            <h2>Failed to load member info</h2>
+                            <p>{e.toString()}</p>
+                        </>,
+                    ),
+                );
             }
         });
 });

--- a/public/ts/member.tsx
+++ b/public/ts/member.tsx
@@ -1348,7 +1348,7 @@ common.documentLoaded().then(() => {
                     jsx_to_string(
                         <>
                             <h2>Failed to load member info</h2>
-                            <p>{e.toString()}</p>
+                            <pre>{JSON.stringify(e)}</pre>
                         </>,
                     ),
                 );

--- a/public/ts/payment_common.tsx
+++ b/public/ts/payment_common.tsx
@@ -1,4 +1,5 @@
 /// <reference path="../node_modules/@types/stripe-v3/index.d.ts" />
+import { render as jsx_to_string } from "preact-render-to-string";
 import { useEffect, useRef } from "preact/hooks";
 import Cart, { Item } from "./cart";
 import * as common from "./common";
@@ -21,6 +22,22 @@ var errorElement: any;
 
 export function initializeStripe() {
     // Create a Stripe client.
+    if (!window.stripeKey) {
+        UIkit.modal.alert(
+            jsx_to_string(
+                <>
+                    <h2>Stripe configuration missing</h2>
+                    <p>You need to set the Stripe keys in your .env file</p>
+                </>,
+            ),
+            {
+                timeout: 0,
+                status: "danger",
+            },
+        );
+        return; // Exit early since otherwise the call below will crash.
+    }
+
     stripe = Stripe(window.stripeKey);
 }
 


### PR DESCRIPTION
Now, if you don't have Stripe configured, you will get the following popups when you try to load `http://localhost:8011`, instead of just seeing a blank page:

1. Error from the backend:
   ![image](https://github.com/user-attachments/assets/4f3fae7c-8b86-4e0a-a454-550497dea519)
2. Error from the frontent:
   ![image](https://github.com/user-attachments/assets/67b30805-cc95-4f2c-91ea-106a39f4c318)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message display when loading member information by rendering as JSON string.
  - Enhanced error handling logic to render additional information when loading member info fails.
  - Added a check for `window.stripeKey` before initializing Stripe and alerting if the key is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->