### PR TITLE
Add docker mountpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ clean-nuke:
 	$(COMPOSE) down
 	docker volume rm -f makeradmin_dbdata
 	docker volume rm -f makeradmin_logs
+	docker volume rm -f makeradmin_accessy_syncer_logs
+	docker volume rm -f makeradmin_email_dispatcher_logs
 	docker volume rm -f makeradmin_node_modules
 	docker volume rm -f test_dbdata
 	docker volume rm -f test_logs

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,10 +18,12 @@ services:
   email-dispatcher:
     volumes:
       - ./api/src:/work/src
+      - email_dispatcher_logs:/work/logs
 
   accessy-syncer:
     volumes:
       - ./api/src:/work/src
+      - accessy_syncer_logs:/work/logs
 
   public:
     build:
@@ -47,3 +49,5 @@ services:
 
 volumes:
   logs:
+  accessy_syncer_logs:
+  email_dispatcher_logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ services:
     image: makeradmin/api:1.0
     build:
       context: ./api
+    volumes:
+      - ./logs/email_dispatcher:/work/logs
     command:
       - "/work/dispatch_emails.sh"
     environment:
@@ -87,6 +89,8 @@ services:
     image: makeradmin/api:1.0
     build:
       context: ./api
+    volumes:
+      - ./logs/accessy_syncer:/work/logs
     command:
       - "/work/accessy_syncer.sh"
     environment:


### PR DESCRIPTION
Add docker mountpoints for accessy-syncer and email-dispatcher to avoid unnamed docker volumes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved logging support by adding volume mappings for email dispatcher and accessy syncer services, aiding in better log management and debugging.
- **Chores**
  - Updated cleanup commands in the `Makefile` to remove additional Docker volumes related to `makeradmin_accessy_syncer` and `makeradmin_email_dispatcher`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->