### PR TITLE
Allow linebreak in boxTerminator info field.

### DIFF
--- a/admin/src/boxTerminator/Termination.tsx
+++ b/admin/src/boxTerminator/Termination.tsx
@@ -50,7 +50,9 @@ export const Termination = ({ props, callback }: TerminationProps) => {
                     ? `expired since: ${props.expired_date}`
                     : `Expires: ${props.expired_date}`}
             </h3>
-            {props.info && <h3>{props.info}</h3>}
+            {props.info && (
+                <h3 style={{ whiteSpace: "pre-line" }}>{props.info}</h3>
+            )}
 
             {props.options
                 ? props.options.map((option) => {

--- a/api/src/box_terminator/views.py
+++ b/api/src/box_terminator/views.py
@@ -22,7 +22,7 @@ def box_terminator_fetch(
                     "member_name": "Test Testsson",
                     "expired": False,
                     "expired_date": "2024-09-09",
-                    "info": "last nagged 2023-09-09",
+                    "info": "last nagged 2023-09-09\nThis is a new line",
                     "storage_id": 1,
                 }
             )


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/37b8bb18-2e5d-433f-a693-a838c6b75ffc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the `Termination` component with improved conditional rendering for better display customization.

- **Chores**
  - Updated `Makefile` to include commands for removing additional Docker volumes.
  - Added volume mappings for logging in `docker-compose` files to improve log management for `email_dispatcher` and `accessy_syncer` services.

- **Bug Fixes**
  - Included additional information in the `info` field for better clarity in `box_terminator_fetch`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->