### PR TITLE
Pin docker images

### DIFF
--- a/admin/DevServerDockerfile
+++ b/admin/DevServerDockerfile
@@ -1,4 +1,4 @@
-FROM node:19-alpine
+FROM node@sha256:8ec543d4795e2e85af924a24f8acb039792ae9fe8a42ad5b4bf4c277ab34b62e
 
 RUN apk add --no-cache tzdata
 ENV TZ Europe/Stockholm

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19-alpine
+FROM node@sha256:8ec543d4795e2e85af924a24f8acb039792ae9fe8a42ad5b4bf4c277ab34b62e
 
 RUN apk add --no-cache tzdata
 ENV TZ Europe/Stockholm
@@ -22,7 +22,7 @@ RUN npm run test
 RUN npm run build
 RUN echo tsc --version
 
-FROM nginx:alpine
+FROM nginx@sha256:16164a43b5faec40adb521e98272edc528e74f31c1352719132b8f7e53418d70
 
 # Configuration file for nginx
 COPY ./docker/nginx_default_host /etc/nginx/conf.d/default.conf

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python@sha256:5d769f990397afbb2aca24b0655e404c0f2806d268f454b052e81e39d87abf42
 
 RUN apk update \
     && apk add \

--- a/api/TestDockerfile
+++ b/api/TestDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python@sha256:004b4029670f2964bb102d076571c9d750c2a43b51c13c768e443c95a71aa9f3
 
 RUN apk update \
     && apk add \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db2:
-    image: mysql:8.0.33
+    image: mysql@sha256:ea68e51ffe9b96fef6076f1218af11301aeaf13c6201e0ec9aaef5791d5ddc5d
     # The lumen library seems to use an older mysql client which is not able to connect if mysql uses the newer caching_sha2_password authentication plugin.
     # Therefore we need to override the mysql starting command to set a config option to use the older password authentication plugin.
     # We need to call the entrypoint script manually because that one will also initialize the database, if one doesn't already exist.

--- a/public/Dockerfile
+++ b/public/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python@sha256:5d769f990397afbb2aca24b0655e404c0f2806d268f454b052e81e39d87abf42
 
 RUN apk update \
 	&& apk add \

--- a/update-docker-images.sh
+++ b/update-docker-images.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+function get_latest_digest() {
+    image_name="$1"
+    tag="$2"
+    docker pull "$image_name:$tag" | awk '/^Digest: / {print $2}'
+}
+
+function update_digest_in_file() {
+    image="$1"
+    digest="$2"
+    file="$3"
+
+    if [[ "$(basename "$file")" =~ ^'docker-compose'*'.yml' ]]; then
+        sed -i 's/^\( *\)image: '"$image"'@.*$/\1image: '"$image@$digest"'/g' "$file"
+    elif [[ "$(basename "$file")" == "Dockerfile" ]]; then
+        sed -i 's/^FROM '"$image"'@.*$/FROM '"$image@$digest"'/g' "$file"
+    else
+        echo "Wrong file ending for '$file'"
+        exit 1
+    fi
+}
+
+function update_digest_in_files() {
+    image="$1"
+    tag="$2"
+    shift 2
+
+    digest=$(get_latest_digest "$image" "$tag")
+    echo "Update digest for $image:$tag to $image@$digest"
+
+    files="$*"
+    for file in $files; do
+        update_digest_in_file "$image" "$digest" "$file"
+    done
+}
+
+function update_all_refs_to_latest_digest() {
+    image="$1"
+    tag="$2"
+    update_digest_in_files "$image" "$tag" \
+        admin/Dockerfile api/Dockerfile public/Dockerfile docker-compose.yml
+}
+
+update_all_refs_to_latest_digest python 3.11-alpine
+update_all_refs_to_latest_digest nginx alpine
+update_all_refs_to_latest_digest node 19-alpine
+update_all_refs_to_latest_digest mysql 8.0.33


### PR DESCRIPTION
Closes #533 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new script `update-docker-images.sh` to help identify Docker images and their SHA256 hashes in the project.
  
- **Chores**
	- Updated base images in multiple Dockerfiles to specific image digests for improved build consistency.
	- Modified the `docker-compose.yml` file to reference the MySQL image by its digest for enhanced stability.
	- Enhanced `update-docker-images.sh` to automate the process of updating Docker image digests in specified files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->