### PR TITLE
replace datetime.utcnow() with datetime.now(timezone.utc)

### DIFF
--- a/api/src/change_phone_request.py
+++ b/api/src/change_phone_request.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from random import randint
 
 from dispatch_sms import NoAuthConfigured, send_validation_code
@@ -15,7 +15,7 @@ logger = logging.getLogger("makeradmin")
 
 
 def change_phone_request(member_id: int | None, phone: str) -> int:
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     try:
         phone = normalise_phone_number(phone)
@@ -88,7 +88,11 @@ def change_phone_request(member_id: int | None, phone: str) -> int:
         raise BadRequest("Misslyckades med att skicka sms med verifikations kod")
 
     change_request = PhoneNumberChangeRequest(
-        member_id=member_id, phone=phone, validation_code=validation_code, completed=False, timestamp=datetime.utcnow()
+        member_id=member_id,
+        phone=phone,
+        validation_code=validation_code,
+        completed=False,
+        timestamp=datetime.now(timezone.utc),
     )
 
     db_session.add(change_request)
@@ -104,7 +108,7 @@ def change_phone_request(member_id: int | None, phone: str) -> int:
 
 def change_phone_validate(member_id: int | None, request_id: int, validation_code: str):
     logging.info(f"member {member_id} validating phone number, code {validation_code}")
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     try:
         change_request = (

--- a/api/src/change_phone_request.py
+++ b/api/src/change_phone_request.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("makeradmin")
 
 
 def change_phone_request(member_id: int | None, phone: str) -> int:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     try:
         phone = normalise_phone_number(phone)
@@ -92,7 +92,7 @@ def change_phone_request(member_id: int | None, phone: str) -> int:
         phone=phone,
         validation_code=validation_code,
         completed=False,
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.now(timezone.utc).replace(tzinfo=None),
     )
 
     db_session.add(change_request)
@@ -108,7 +108,7 @@ def change_phone_request(member_id: int | None, phone: str) -> int:
 
 def change_phone_validate(member_id: int | None, request_id: int, validation_code: str):
     logging.info(f"member {member_id} validating phone number, code {validation_code}")
-    now = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     try:
         change_request = (

--- a/api/src/core/auth.py
+++ b/api/src/core/auth.py
@@ -1,5 +1,5 @@
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging import getLogger
 from string import ascii_letters, digits
 from typing import Optional
@@ -57,7 +57,7 @@ def create_access_token(ip: str, browser: Optional[str], user_id: int, valid_dur
         access_token=generate_token(),
         browser=browser,
         ip=ip,
-        expires=datetime.utcnow() + (timedelta(minutes=15) if valid_duration is None else valid_duration),
+        expires=datetime.now(timezone.utc) + (timedelta(minutes=15) if valid_duration is None else valid_duration),
         lifetime=int(timedelta(days=14).total_seconds()),
     )
 
@@ -122,7 +122,7 @@ def password_reset(reset_token, unhashed_password):
     except MultipleResultsFound:
         raise InternalServerError(log=f"Multiple tokens {reset_token} found, this is a bug.")
 
-    if datetime.utcnow() - password_reset_token.created_at > timedelta(minutes=10):
+    if datetime.now(timezone.utc) - password_reset_token.created_at > timedelta(minutes=10):
         raise UnprocessableEntity("Reset link expired, try to request a new one.")
 
     try:

--- a/api/src/core/auth.py
+++ b/api/src/core/auth.py
@@ -57,7 +57,8 @@ def create_access_token(ip: str, browser: Optional[str], user_id: int, valid_dur
         access_token=generate_token(),
         browser=browser,
         ip=ip,
-        expires=datetime.now(timezone.utc) + (timedelta(minutes=15) if valid_duration is None else valid_duration),
+        expires=datetime.now(timezone.utc).replace(tzinfo=None)
+        + (timedelta(minutes=15) if valid_duration is None else valid_duration),
         lifetime=int(timedelta(days=14).total_seconds()),
     )
 
@@ -122,7 +123,7 @@ def password_reset(reset_token, unhashed_password):
     except MultipleResultsFound:
         raise InternalServerError(log=f"Multiple tokens {reset_token} found, this is a bug.")
 
-    if datetime.now(timezone.utc) - password_reset_token.created_at > timedelta(minutes=10):
+    if datetime.now(timezone.utc).replace(tzinfo=None) - password_reset_token.created_at > timedelta(minutes=10):
         raise UnprocessableEntity("Reset link expired, try to request a new one.")
 
     try:

--- a/api/src/dispatch_emails.py
+++ b/api/src/dispatch_emails.py
@@ -1,7 +1,7 @@
 import time
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from contextlib import closing
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from os.path import abspath, dirname
 from time import sleep
 from typing import Optional
@@ -88,7 +88,7 @@ def send_messages(key: Optional[str], domain: str, sender: str, to_override: Opt
 
         if response.ok:
             message.status = Message.SENT
-            message.sent_at = datetime.utcnow()
+            message.sent_at = datetime.now(timezone.utc)
 
             db_session.add(message)
             db_session.commit()
@@ -104,7 +104,7 @@ def send_messages(key: Optional[str], domain: str, sender: str, to_override: Opt
 
 def already_sent_message(template: MessageTemplate, member: Member, days: int):
     """True if a message has been sent with the given template to the member in the last #days days"""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     reminder_sent = (
         db_session.query(Message)
         .filter(
@@ -118,7 +118,7 @@ def already_sent_message(template: MessageTemplate, member: Member, days: int):
 
 
 def labaccess_reminder() -> None:
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     end_date_reminder_target = now.date() + timedelta(days=LABACCESS_REMINDER_DAYS_BEFORE)
 
@@ -172,7 +172,7 @@ def labaccess_reminder() -> None:
 
 
 def membership_reminder() -> None:
-    now = datetime.utcnow().date()
+    now = datetime.now(timezone.utc).date()
 
     members, memberships = get_members_and_membership()
     members = list(members)
@@ -227,7 +227,7 @@ def quiz_reminders() -> None:
     # Assume quiz 1 is the get started quiz
     quiz_id = 1
     quiz_members = quiz_member_answer_stats(quiz_id)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     members, memberships = get_members_and_membership()
     id_to_member = {member.member_id: (member, membership) for member, membership in zip(members, memberships)}

--- a/api/src/dispatch_emails.py
+++ b/api/src/dispatch_emails.py
@@ -88,7 +88,7 @@ def send_messages(key: Optional[str], domain: str, sender: str, to_override: Opt
 
         if response.ok:
             message.status = Message.SENT
-            message.sent_at = datetime.now(timezone.utc)
+            message.sent_at = datetime.now(timezone.utc).replace(tzinfo=None)
 
             db_session.add(message)
             db_session.commit()
@@ -104,7 +104,7 @@ def send_messages(key: Optional[str], domain: str, sender: str, to_override: Opt
 
 def already_sent_message(template: MessageTemplate, member: Member, days: int):
     """True if a message has been sent with the given template to the member in the last #days days"""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     reminder_sent = (
         db_session.query(Message)
         .filter(
@@ -118,7 +118,7 @@ def already_sent_message(template: MessageTemplate, member: Member, days: int):
 
 
 def labaccess_reminder() -> None:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     end_date_reminder_target = now.date() + timedelta(days=LABACCESS_REMINDER_DAYS_BEFORE)
 
@@ -172,7 +172,7 @@ def labaccess_reminder() -> None:
 
 
 def membership_reminder() -> None:
-    now = datetime.now(timezone.utc).date()
+    now = datetime.now(timezone.utc).replace(tzinfo=None).date()
 
     members, memberships = get_members_and_membership()
     members = list(members)
@@ -227,7 +227,7 @@ def quiz_reminders() -> None:
     # Assume quiz 1 is the get started quiz
     quiz_id = 1
     quiz_members = quiz_member_answer_stats(quiz_id)
-    now = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     members, memberships = get_members_and_membership()
     id_to_member = {member.member_id: (member, membership) for member, membership in zip(members, memberships)}

--- a/api/src/firstrun.py
+++ b/api/src/firstrun.py
@@ -1,6 +1,6 @@
 import argparse
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from getpass import getpass
 from typing import Any, Dict, Generic, Literal, Optional, Tuple, TypeVar, cast
 
@@ -452,7 +452,12 @@ def create_shop_transactions() -> None:
     transaction = get_or_create(
         Transaction,
         id=index,
-        defaults=dict(member_id=1, amount=membership_prod.price, status="completed", created_at=datetime.now()),
+        defaults=dict(
+            member_id=1,
+            amount=membership_prod.price,
+            status="completed",
+            created_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        ),
     )
     transaction_content = get_or_create(
         TransactionContent,
@@ -472,7 +477,7 @@ def create_shop_transactions() -> None:
             action_type="add_labaccess_days",
             value=10,
             status="completed",
-            completed_at=datetime.now(),
+            completed_at=datetime.now(timezone.utc).replace(tzinfo=None),
         ),
     )
     index += 1
@@ -485,7 +490,7 @@ def create_shop_transactions() -> None:
             member_id=None,
             amount=100,
             status="completed",
-            created_at=datetime.now(),
+            created_at=datetime.now(timezone.utc).replace(tzinfo=None),
         ),
     )
 

--- a/api/src/init_db.py
+++ b/api/src/init_db.py
@@ -2,7 +2,7 @@
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from contextlib import closing
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from core.auth import generate_token
 from core.models import AccessToken
@@ -44,7 +44,7 @@ def refresh_service_access_tokens(session_factory):
                     raise Exception(f"Found multiple of service token id {service_user.id}, this is a bug.") from e
 
                 access_token.lifetime = ten_years.total_seconds()
-                access_token.expires = datetime.utcnow() + ten_years
+                access_token.expires = datetime.now(timezone.utc) + ten_years
 
                 session.add(access_token)
             else:

--- a/api/src/init_db.py
+++ b/api/src/init_db.py
@@ -44,7 +44,7 @@ def refresh_service_access_tokens(session_factory):
                     raise Exception(f"Found multiple of service token id {service_user.id}, this is a bug.") from e
 
                 access_token.lifetime = ten_years.total_seconds()
-                access_token.expires = datetime.now(timezone.utc) + ten_years
+                access_token.expires = datetime.now(timezone.utc).replace(tzinfo=None) + ten_years
 
                 session.add(access_token)
             else:

--- a/api/src/member/member.py
+++ b/api/src/member/member.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, List
 from urllib.parse import quote_plus
@@ -30,7 +30,7 @@ def send_access_token_email(redirect, user_identification, ip, browser):
         MessageTemplate.LOGIN_LINK,
         member,
         url=url,
-        now=format_datetime(datetime.now()),
+        now=format_datetime(datetime.now(timezone.utc).replace(tzinfo=None)),
     )
 
     return {"status": "sent"}
@@ -47,7 +47,7 @@ def send_updated_member_info_email(member_id: int, msg_swe: str, msg_en: str):
     send_message(
         MessageTemplate.UPDATED_MEMBER_INFO,
         member,
-        now=format_datetime(datetime.now()),
+        now=format_datetime(datetime.now(timezone.utc).replace(tzinfo=None)),
         message_swe=msg_swe,
         message_en=msg_en,
     )

--- a/api/src/migrate.py
+++ b/api/src/migrate.py
@@ -1,7 +1,7 @@
 import re
 from collections import namedtuple
 from contextlib import closing
-from datetime import datetime
+from datetime import datetime, timezone
 from inspect import getfile, getmodule, stack
 from os import listdir
 from os.path import dirname, exists, isdir, join
@@ -119,7 +119,7 @@ def run_migrations(session_factory):
 
                 session.execute(
                     "INSERT INTO migrations VALUES (:id, :name, :applied_at)",
-                    {"id": migration.id, "name": migration.name, "applied_at": datetime.utcnow()},
+                    {"id": migration.id, "name": migration.name, "applied_at": datetime.now(timezone.utc)},
                 )
                 session.commit()
             except Exception:

--- a/api/src/migrate.py
+++ b/api/src/migrate.py
@@ -119,7 +119,11 @@ def run_migrations(session_factory):
 
                 session.execute(
                     "INSERT INTO migrations VALUES (:id, :name, :applied_at)",
-                    {"id": migration.id, "name": migration.name, "applied_at": datetime.now(timezone.utc)},
+                    {
+                        "id": migration.id,
+                        "name": migration.name,
+                        "applied_at": datetime.now(timezone.utc).replace(tzinfo=None),
+                    },
                 )
                 session.commit()
             except Exception:

--- a/api/src/multiaccess/box_terminator.py
+++ b/api/src/multiaccess/box_terminator.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from membership.models import Box, Member, Span
 from messages.message import send_message
@@ -98,7 +98,7 @@ def box_terminator_nag(member_number=None, box_label_id=None, nag_type=None):
         days_after_expiration=(today - end_date).days,
     )
 
-    box.last_nag_at = datetime.utcnow()
+    box.last_nag_at = datetime.now(timezone.utc)
 
 
 def box_terminator_validate(member_number=None, box_label_id=None, session_token=None):
@@ -114,7 +114,7 @@ def box_terminator_validate(member_number=None, box_label_id=None, session_token
 
         box = Box(member_id=member.member_id, box_label_id=box_label_id)
 
-    box.last_check_at = datetime.utcnow()
+    box.last_check_at = datetime.now(timezone.utc)
     box.session_token = session_token
     db_session.add(box)
     db_session.flush()

--- a/api/src/multiaccess/box_terminator.py
+++ b/api/src/multiaccess/box_terminator.py
@@ -98,7 +98,7 @@ def box_terminator_nag(member_number=None, box_label_id=None, nag_type=None):
         days_after_expiration=(today - end_date).days,
     )
 
-    box.last_nag_at = datetime.now(timezone.utc)
+    box.last_nag_at = datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 def box_terminator_validate(member_number=None, box_label_id=None, session_token=None):
@@ -114,7 +114,7 @@ def box_terminator_validate(member_number=None, box_label_id=None, session_token
 
         box = Box(member_id=member.member_id, box_label_id=box_label_id)
 
-    box.last_check_at = datetime.now(timezone.utc)
+    box.last_check_at = datetime.now(timezone.utc).replace(tzinfo=None)
     box.session_token = session_token
     db_session.add(box)
     db_session.flush()

--- a/api/src/multiaccessy/accessy.py
+++ b/api/src/multiaccessy/accessy.py
@@ -3,7 +3,7 @@ import threading
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from enum import Enum
 from logging import getLogger
 from random import random
@@ -361,9 +361,9 @@ class AccessySession:
             if (
                 not self.session_token
                 or self.session_token_token_expires_at is None
-                or datetime.now() > self.session_token_token_expires_at
+                or datetime.now(timezone.utc).replace(tzinfo=None) > self.session_token_token_expires_at
             ):
-                now = datetime.now()
+                now = datetime.now(timezone.utc).replace(tzinfo=None)
                 data = request(
                     "post",
                     "/auth/oauth/token",

--- a/api/src/service/auth.py
+++ b/api/src/service/auth.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import membership.member_auth
 from core.models import AccessToken
@@ -37,7 +37,7 @@ def authenticate_request() -> None:
     if not access_token:
         raise Unauthorized("Unauthorized, invalid access token.", fields="bearer", what=BAD_VALUE)
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     if access_token.expires < now:
         db_session.query(AccessToken).filter(AccessToken.expires < now).delete()
         raise Unauthorized("Unauthorized, expired access token.", fields="bearer", what=EXPIRED)
@@ -60,7 +60,7 @@ def authenticate_request() -> None:
 
     access_token.ip = request.remote_addr
     access_token.browser = request.user_agent.string
-    access_token.expires = datetime.utcnow() + timedelta(seconds=access_token.lifetime)
+    access_token.expires = datetime.now(timezone.utc) + timedelta(seconds=access_token.lifetime)
 
     g.user_id = access_token.user_id
     g.session_token = access_token.access_token

--- a/api/src/service/auth.py
+++ b/api/src/service/auth.py
@@ -37,7 +37,7 @@ def authenticate_request() -> None:
     if not access_token:
         raise Unauthorized("Unauthorized, invalid access token.", fields="bearer", what=BAD_VALUE)
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     if access_token.expires < now:
         db_session.query(AccessToken).filter(AccessToken.expires < now).delete()
         raise Unauthorized("Unauthorized, expired access token.", fields="bearer", what=EXPIRED)
@@ -60,7 +60,7 @@ def authenticate_request() -> None:
 
     access_token.ip = request.remote_addr
     access_token.browser = request.user_agent.string
-    access_token.expires = datetime.now(timezone.utc) + timedelta(seconds=access_token.lifetime)
+    access_token.expires = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=access_token.lifetime)
 
     g.user_id = access_token.user_id
     g.session_token = access_token.access_token

--- a/api/src/service/entity.py
+++ b/api/src/service/entity.py
@@ -1,6 +1,6 @@
 from base64 import b64decode, b64encode
 from collections import namedtuple
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from logging import getLogger
 from math import ceil
@@ -340,7 +340,7 @@ class Entity:
             raise NotFound("Could not find any entity with specified parameters.")
 
         if not entity.deleted_at:
-            entity.deleted_at = datetime.utcnow()
+            entity.deleted_at = datetime.now(timezone.utc)
 
         if commit:
             db_session.commit()

--- a/api/src/service/entity.py
+++ b/api/src/service/entity.py
@@ -340,7 +340,7 @@ class Entity:
             raise NotFound("Could not find any entity with specified parameters.")
 
         if not entity.deleted_at:
-            entity.deleted_at = datetime.now(timezone.utc)
+            entity.deleted_at = datetime.now(timezone.utc).replace(tzinfo=None)
 
         if commit:
             db_session.commit()

--- a/api/src/service/traffic_logger.py
+++ b/api/src/service/traffic_logger.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 from flask import Request as FlaskRequest
@@ -20,7 +20,7 @@ class TrafficLogger:
     service_traffic: List[object]
 
     def __init__(self) -> None:
-        self.create_time = datetime.utcnow().isoformat() + "Z"
+        self.create_time = datetime.now(timezone.utc).isoformat() + "Z"
         self.service_traffic = list()
 
     def log_service_traffic(self, traffic: Response) -> None:
@@ -47,7 +47,7 @@ class TrafficLogger:
             "query": session_request.args,
         }
         session_response_data = {
-            "date": datetime.utcnow().isoformat() + "Z",
+            "date": datetime.now(timezone.utc).isoformat() + "Z",
             "status": session_response.status_code,
             "headers": dict(session_response.headers),
         }

--- a/api/src/service/traffic_logger.py
+++ b/api/src/service/traffic_logger.py
@@ -20,7 +20,7 @@ class TrafficLogger:
     service_traffic: List[object]
 
     def __init__(self) -> None:
-        self.create_time = datetime.now(timezone.utc).isoformat() + "Z"
+        self.create_time = datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z"
         self.service_traffic = list()
 
     def log_service_traffic(self, traffic: Response) -> None:
@@ -47,7 +47,7 @@ class TrafficLogger:
             "query": session_request.args,
         }
         session_response_data = {
-            "date": datetime.now(timezone.utc).isoformat() + "Z",
+            "date": datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
             "status": session_response.status_code,
             "headers": dict(session_response.headers),
         }

--- a/api/src/shop/accounting/sie_file.py
+++ b/api/src/shop/accounting/sie_file.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from logging import getLogger
 from typing import Dict, List, Tuple
@@ -35,7 +35,7 @@ def date_format(dt: datetime) -> str:
 
 def get_header(signer: str, start_date: datetime, end_date: datetime) -> str:
     return HEADER_TEMPLATE.format(
-        date=date_format(datetime.now()),
+        date=date_format(datetime.now(timezone.utc).replace(tzinfo=None)),
         signer=signer,
         date_start=date_format(start_date),
         date_end=date_format(end_date),

--- a/api/src/shop/accounting/test/export_test.py
+++ b/api/src/shop/accounting/test/export_test.py
@@ -175,7 +175,7 @@ class AccountingExportWithStripeMockTest(FlaskTestBase):
             row = sie_rows.pop(0)
 
             if row.startswith("#GEN"):
-                assert datetime.now().strftime("%Y%m%d") in row
+                assert datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y%m%d") in row
                 assert self.member.firstname in row
                 assert self.member.lastname in row
 

--- a/api/src/shop/accounting/test/sie_file_test.py
+++ b/api/src/shop/accounting/test/sie_file_test.py
@@ -157,7 +157,7 @@ class SieFileWithVerificationTest(FlaskTestBase):
             row = sie_rows.pop(0)
 
             if row.startswith("#GEN"):
-                assert datetime.now().strftime("%Y%m%d") in row
+                assert datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y%m%d") in row
                 assert signer in row
 
             if row.startswith("#DIM"):

--- a/api/src/shop/pay.py
+++ b/api/src/shop/pay.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from logging import getLogger
 from typing import Any, List, Optional
@@ -247,7 +247,9 @@ def cleanup_pending_members(relevant_email: str) -> None:
         db_session.query(Member)
         .filter(
             (Member.pending_activation == True)
-            & ((Member.email == relevant_email) | (Member.created_at < datetime.utcnow() - timedelta(hours=1))),
+            & (
+                (Member.email == relevant_email) | (Member.created_at < datetime.now(timezone.utc) - timedelta(hours=1))
+            ),
         )
         .all()
     )
@@ -314,7 +316,7 @@ def register(data_dict: Any, remote_addr: str, user_agent: str) -> RegisterRespo
     # Mark the member as deleted, so that it is not visible in the member list, and it cannot be used to log in
     # We cannot pass the deleted_at parameter to the create function because it the API prevents that field from being set.
     member = db_session.query(Member).filter(Member.member_id == member_id).one()
-    member.deleted_at = datetime.utcnow()
+    member.deleted_at = datetime.now(timezone.utc)
     db_session.flush()
 
     token = auth.force_login(remote_addr, user_agent, member_id)["access_token"]

--- a/api/src/shop/pay.py
+++ b/api/src/shop/pay.py
@@ -248,7 +248,8 @@ def cleanup_pending_members(relevant_email: str) -> None:
         .filter(
             (Member.pending_activation == True)
             & (
-                (Member.email == relevant_email) | (Member.created_at < datetime.now(timezone.utc) - timedelta(hours=1))
+                (Member.email == relevant_email)
+                | (Member.created_at < datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=1))
             ),
         )
         .all()
@@ -316,7 +317,7 @@ def register(data_dict: Any, remote_addr: str, user_agent: str) -> RegisterRespo
     # Mark the member as deleted, so that it is not visible in the member list, and it cannot be used to log in
     # We cannot pass the deleted_at parameter to the create function because it the API prevents that field from being set.
     member = db_session.query(Member).filter(Member.member_id == member_id).one()
-    member.deleted_at = datetime.now(timezone.utc)
+    member.deleted_at = datetime.now(timezone.utc).replace(tzinfo=None)
     db_session.flush()
 
     token = auth.force_login(remote_addr, user_agent, member_id)["access_token"]

--- a/api/src/shop/transactions.py
+++ b/api/src/shop/transactions.py
@@ -173,7 +173,7 @@ def pending_action_value_sum(member_id: int, action_type: str) -> int:
 
 def complete_pending_action(action: TransactionAction) -> None:
     action.status = TransactionAction.COMPLETED
-    action.completed_at = datetime.utcnow()
+    action.completed_at = datetime.now(timezone.utc)
     db_session.add(action)
     db_session.flush()
 

--- a/api/src/shop/transactions.py
+++ b/api/src/shop/transactions.py
@@ -173,7 +173,7 @@ def pending_action_value_sum(member_id: int, action_type: str) -> int:
 
 def complete_pending_action(action: TransactionAction) -> None:
     action.status = TransactionAction.COMPLETED
-    action.completed_at = datetime.now(timezone.utc)
+    action.completed_at = datetime.now(timezone.utc).replace(tzinfo=None)
     db_session.add(action)
     db_session.flush()
 

--- a/api/src/statistics/maker_statistics.py
+++ b/api/src/statistics/maker_statistics.py
@@ -2,7 +2,7 @@ import itertools
 import math
 import time
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from membership.membership import get_members_and_membership, get_membership_summaries
@@ -138,7 +138,7 @@ def membership_number_months2(membership_type: str, startdate: date, enddate: da
 
 
 def membership_number_months_default():
-    now = datetime.now()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     starttime = now - timedelta(days=30 * 12)
     return {
         "membership": membership_number_months("membership", starttime.date(), now.date()),
@@ -147,7 +147,7 @@ def membership_number_months_default():
 
 
 def membership_number_months2_default():
-    now = datetime.now()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     starttime = now - timedelta(days=30 * 12)
     return {
         "membership": membership_number_months2("membership", starttime.date(), now.date()),
@@ -212,7 +212,7 @@ def shop_statistics() -> ShopStatistics:
     def mapify(rows: List[Tuple[Any, Any]]) -> Dict[Any, Any]:
         return {r[0]: r[1] for r in rows}
 
-    date_lower_limit = datetime.now() - timedelta(days=365)
+    date_lower_limit = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=365)
 
     sales_by_product: Dict[int, float] = mapify(
         db_session.query(TransactionContent.product_id, func.sum(TransactionContent.amount))

--- a/api/src/systest/api/box_terminator_test.py
+++ b/api/src/systest/api/box_terminator_test.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from random import randint
 from unittest import skip
 
@@ -90,7 +90,7 @@ class Test(ApiTest):
     def test_box_terminator_validate_deleted_span_is_filtered(self):
         member = self.db.create_member()
         box = self.db.create_box()
-        span = self.db.create_span(enddate=self.date(10), type=Span.LABACCESS, deleted_at=datetime.utcnow())
+        span = self.db.create_span(enddate=self.date(10), type=Span.LABACCESS, deleted_at=datetime.now(timezone.utc))
 
         self.api.post(
             "/multiaccess/box-terminator/validate-box",

--- a/api/src/systest/api/box_terminator_test.py
+++ b/api/src/systest/api/box_terminator_test.py
@@ -90,7 +90,9 @@ class Test(ApiTest):
     def test_box_terminator_validate_deleted_span_is_filtered(self):
         member = self.db.create_member()
         box = self.db.create_box()
-        span = self.db.create_span(enddate=self.date(10), type=Span.LABACCESS, deleted_at=datetime.now(timezone.utc))
+        span = self.db.create_span(
+            enddate=self.date(10), type=Span.LABACCESS, deleted_at=datetime.now(timezone.utc).replace(tzinfo=None)
+        )
 
         self.api.post(
             "/multiaccess/box-terminator/validate-box",

--- a/api/src/systest/api/change_phone_request_test.py
+++ b/api/src/systest/api/change_phone_request_test.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from random import randint
 from time import sleep
 from unittest import skip
@@ -16,7 +16,7 @@ from test_aid.systest_base import ApiTest
 class Test(ApiTest):
     @patch("change_phone_request.send_validation_code")
     def test_request_and_validate(self, mock_send_validation_code):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         new_phone = "+461234567"
         member = self.db.create_member()
         old_phone = member.phone
@@ -71,7 +71,7 @@ class Test(ApiTest):
 
     @patch("change_phone_request.send_validation_code")
     def test_validate_wrong_code(self, mock_send_validation_code):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         new_phone = "+461234567"
         member = self.db.create_member()
         old_phone = member.phone
@@ -111,7 +111,7 @@ class Test(ApiTest):
 
     @patch("change_phone_request.send_validation_code")
     def test_validate_already_used_code(self, mock_send_validation_code):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         new_phone = "+461234567"
         member = self.db.create_member()
         old_phone = member.phone
@@ -152,7 +152,7 @@ class Test(ApiTest):
 
     @patch("change_phone_request.send_validation_code")
     def test_validate_mult_reqs_one_member(self, mock_send_validation_code):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         member = self.db.create_member()
         self.db.create_phone_request(timestamp=now - timedelta(hours=1))
         self.db.create_phone_request(timestamp=now - timedelta(hours=2))
@@ -193,7 +193,7 @@ class Test(ApiTest):
 
     @patch("change_phone_request.send_validation_code")
     def test_validate_mult_reqs_mult_members(self, mock_send_validation_code):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         num_members = 20
 
         member = [None] * num_members

--- a/api/src/systest/api/change_phone_request_test.py
+++ b/api/src/systest/api/change_phone_request_test.py
@@ -16,7 +16,7 @@ from test_aid.systest_base import ApiTest
 class Test(ApiTest):
     @patch("change_phone_request.send_validation_code")
     def test_request_and_validate(self, mock_send_validation_code):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         new_phone = "+461234567"
         member = self.db.create_member()
         old_phone = member.phone
@@ -71,7 +71,7 @@ class Test(ApiTest):
 
     @patch("change_phone_request.send_validation_code")
     def test_validate_wrong_code(self, mock_send_validation_code):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         new_phone = "+461234567"
         member = self.db.create_member()
         old_phone = member.phone
@@ -111,7 +111,7 @@ class Test(ApiTest):
 
     @patch("change_phone_request.send_validation_code")
     def test_validate_already_used_code(self, mock_send_validation_code):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         new_phone = "+461234567"
         member = self.db.create_member()
         old_phone = member.phone
@@ -152,7 +152,7 @@ class Test(ApiTest):
 
     @patch("change_phone_request.send_validation_code")
     def test_validate_mult_reqs_one_member(self, mock_send_validation_code):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         member = self.db.create_member()
         self.db.create_phone_request(timestamp=now - timedelta(hours=1))
         self.db.create_phone_request(timestamp=now - timedelta(hours=2))
@@ -193,7 +193,7 @@ class Test(ApiTest):
 
     @patch("change_phone_request.send_validation_code")
     def test_validate_mult_reqs_mult_members(self, mock_send_validation_code):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         num_members = 20
 
         member = [None] * num_members

--- a/api/src/test_aid/obj.py
+++ b/api/src/test_aid/obj.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from logging import getLogger
 from random import choice, randint, seed
@@ -81,7 +81,7 @@ class ObjFactory:
             phone=random_phone_number(),
             validation_code=randint(1, 999999),
             completed=False,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(timezone.utc).replace(tzinfo=None),
         )
         obj.update(kwargs)
         self.phone_request = obj

--- a/api/src/test_aid/test_base.py
+++ b/api/src/test_aid/test_base.py
@@ -1,6 +1,6 @@
 import time
 from copy import copy
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from unittest import TestCase
 
 from flask import Flask
@@ -27,7 +27,7 @@ class TestBase(TestCase):
         super().setUpClass()
         self.obj = ObjFactory(self)
 
-        self.now = datetime.utcnow()
+        self.now = datetime.now(timezone.utc)
         self.today = self.now.date()
 
     @classinstancemethod

--- a/api/src/test_aid/test_base.py
+++ b/api/src/test_aid/test_base.py
@@ -27,7 +27,7 @@ class TestBase(TestCase):
         super().setUpClass()
         self.obj = ObjFactory(self)
 
-        self.now = datetime.now(timezone.utc)
+        self.now = datetime.now(timezone.utc).replace(tzinfo=None)
         self.today = self.now.date()
 
     @classinstancemethod

--- a/devel_data.py
+++ b/devel_data.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import json
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pprint import pprint
 
 import requests
@@ -80,8 +80,8 @@ for member_id in range(2, 200):
         member = create_user("test user", "blah", f"test_user_{random.randrange(0, 100000)}", "user", None)
 
     delete_all_spans(member["member_id"])
-    startTime = datetime.now() + timedelta(days=random.randrange(-300, 0))
-    endTime = datetime.now() + timedelta(days=random.randrange(-300, 100))
+    startTime = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=random.randrange(-300, 0))
+    endTime = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=random.randrange(-300, 100))
     startTime = startTime.strftime("%Y-%m-%d")
     endTime = endTime.strftime("%Y-%m-%d")
     create_span(member["member_id"], startTime, endTime, "membership", str(random.randrange(0, 100000)))


### PR DESCRIPTION
Solves #508 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced timestamp handling across various functionalities to ensure timezone awareness.

- **Bug Fixes**
	- Corrected timestamp retrieval methods in multiple components, improving accuracy for logging and validation processes.

- **Documentation**
	- Updated import statements to include timezone support for better datetime management.

These changes improve the consistency and reliability of time-related operations throughout the application, ensuring all timestamps are accurately recorded in UTC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->