### PR TITLE
Fix abrevrvation for accounting, move shop docs to docs folder

### DIFF
--- a/api/src/shop/accounting/export.py
+++ b/api/src/shop/accounting/export.py
@@ -33,9 +33,7 @@ def transaction_fees_to_transaction_with_accounting(
 ) -> List[TransactionWithAccounting]:
     amounts: List[TransactionWithAccounting] = []
     account = TransactionAccount(account="6573", description="6573", id=0, display_order=1)
-    cost_center = TransactionCostCenter(
-        cost_center="Föreningsgemensamt", description="Föreningsgemensamt", id=0, display_order=1
-    )
+    cost_center = TransactionCostCenter(cost_center="FG", description="Föreningsgemensamt", id=0, display_order=1)
     for payment in completed_payments.values():
         amounts.append(
             TransactionWithAccounting(

--- a/api/src/shop/accounting/test/export_test.py
+++ b/api/src/shop/accounting/test/export_test.py
@@ -54,7 +54,7 @@ class ExportTest(TestCase):
         for i in range(num_payments):
             self.assertEqual(transaction_fees[i].amount, true_fees[i])
             assert transaction_fees[i].account.account == "6573"
-            assert transaction_fees[i].cost_center.cost_center == "Föreningsgemensamt"
+            assert transaction_fees[i].cost_center.cost_center == "FG"
 
 
 class AccountingExportWithStripeMockTest(FlaskTestBase):
@@ -192,7 +192,7 @@ class AccountingExportWithStripeMockTest(FlaskTestBase):
             assert verification_row.strip() == "{"
 
             transaction_row = sie_rows.pop(0)
-            assert transaction_row.startswith(f'#TRANS 6573 {{1 "Föreningsgemensamt"}} 3.00 2023{i:02d}01')
+            assert transaction_row.startswith(f'#TRANS 6573 {{1 "FG"}} 3.00 2023{i:02d}01')
 
             for j in range(4):
                 transaction_row = sie_rows.pop(0)

--- a/docs/src/dev-guide/shop.md
+++ b/docs/src/dev-guide/shop.md
@@ -1,6 +1,6 @@
 # Stripe
 
-For the general introduction to how we use Stripe, see the main [readme](../../../README.md)
+We use stripe for the payments.
 
 ## Makeradmin stripe relationships
 


### PR DESCRIPTION
Fix Föreningsgemensamt not using the abrivration in the correct places. Move shop docs to the new docs folder