### PR TITLE
Improve accessy syncing performance and improve code-reuse.

### DIFF
--- a/api/src/membership/membership.py
+++ b/api/src/membership/membership.py
@@ -145,6 +145,11 @@ def get_membership_summaries(member_ids: List[int], at_date: Optional[date] = No
                 membership_end=membership_end.get(id),
                 membership_active=id in membership_active,
                 effective_labaccess_end=max_or_none(labaccess_end.get(id), special_labaccess_end.get(id)),
+                # The effective labaccess is active if the member has normal or special labaccess
+                # The membership agreement does not matter here.
+                # If the user has the appropriate spans, then they get access.
+                # However, the spans are typically not added until the membership agreement is signed,
+                # as labaccess order actions will stay pending.
                 effective_labaccess_active=(id in labaccess_active) or (id in special_labaccess_active),
             )
         )

--- a/api/src/multiaccessy/sync.py
+++ b/api/src/multiaccessy/sync.py
@@ -20,12 +20,6 @@ from multiaccessy.accessy import (
 logger = getLogger("makeradmin")
 
 
-GROUPS = {
-    Span.SPECIAL_LABACESS: ACCESSY_SPECIAL_LABACCESS_GROUP,
-    Span.LABACCESS: ACCESSY_LABACCESS_GROUP,
-}
-
-
 def get_wanted_access(today: date, member_id: Optional[int] = None) -> dict[PHONE, AccessyMember]:
     if member_id is not None:
         member = db_session.query(Member).get(member_id)

--- a/api/src/multiaccessy/sync.py
+++ b/api/src/multiaccessy/sync.py
@@ -2,8 +2,9 @@
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from logging import getLogger
-from typing import Dict, List
+from typing import Dict, List, Optional
 
+from membership.membership import get_members_and_membership, get_membership_summaries, get_membership_summary
 from membership.models import Member, Span
 from service.db import db_session
 from sqlalchemy.orm import contains_eager
@@ -25,28 +26,33 @@ GROUPS = {
 }
 
 
-def get_wanted_access(today) -> dict[PHONE, AccessyMember]:
-    query = db_session.query(Member).join(Member.spans)
-    query = query.options(contains_eager(Member.spans))
-    query = query.filter(
-        Member.deleted_at.is_(None),
-        Member.phone.is_not(None),
-        Member.labaccess_agreement_at.is_not(None),
-        Span.type.in_([Span.LABACCESS, Span.SPECIAL_LABACESS]),
-        Span.startdate <= today,
-        Span.enddate >= today,
-        Span.deleted_at.is_(None),
-    )
+def get_wanted_access(today: date, member_id: Optional[int] = None) -> dict[PHONE, AccessyMember]:
+    if member_id is not None:
+        member = db_session.query(Member).get(member_id)
+        if member is None:
+            raise Exception("Member does not exist")
+        members = [member]
+        summaries = [get_membership_summary(member_id, at_date=today)]
+    else:
+        members, summaries = get_members_and_membership(at_date=today)
 
     return {
-        m.phone: AccessyMember(
-            phone=m.phone,
-            name=f"{m.firstname} {m.lastname}",
-            groups={GROUPS[span.type] for span in m.spans},
-            member_id=m.member_id,
-            member_number=m.member_number,
+        member.phone: AccessyMember(
+            phone=member.phone,
+            name=f"{member.firstname} {member.lastname}",
+            groups={
+                group
+                for group, enabled in {
+                    ACCESSY_SPECIAL_LABACCESS_GROUP: membership.special_labaccess_active,
+                    ACCESSY_LABACCESS_GROUP: membership.labaccess_active,
+                }.items()
+                if enabled
+            },
+            member_id=member.member_id,
+            member_number=member.member_number,
         )
-        for m in query
+        for member, membership in zip(members, summaries)
+        if member.phone is not None and membership.effective_labaccess_active
     }
 
 
@@ -98,7 +104,7 @@ def calculate_diff(actual_members: Dict[str, AccessyMember], wanted_members: Dic
     return diff
 
 
-def sync(today=None):
+def sync(today: Optional[date] = None, member_id: Optional[int] = None) -> None:
     if accessy_session is None:
         logger.info(f"accessy sync skipped, accessy not configured.")
         return
@@ -106,37 +112,53 @@ def sync(today=None):
     if not today:
         today = date.today()
 
-    actual_members = accessy_session.get_all_members()
+    # If a specific member is given, sync only that member,
+    # otherwise sync all members
+    if member_id is not None:
+        member = db_session.query(Member).get(member_id)
+        if member is None:
+            raise Exception("Member does not exist")
+        if member.phone is None:
+            return
+        accessy_member = accessy_session._get_org_user_from_phone(member.phone)
+        actual_members = [accessy_member] if accessy_member is not None else []
+    else:
+        actual_members = accessy_session.get_all_members()
+
     pending_invites = accessy_session.get_pending_invitations(after_date=today - timedelta(days=7))
-    wanted_members = get_wanted_access(today)
+    wanted_members = get_wanted_access(today, member_id=member_id)
 
     actual_members_by_phone = {}
+    members_to_discard: List[AccessyMember] = []
     for m in actual_members:
         if m.phone:
             actual_members_by_phone[m.phone] = m
         else:
-            logger.warning(
-                f"accessy sync got member %s from accessy without phone number, skipping in calculation, will probably cause extra invite or delayed org remove",
-                m,
-            )
+            # Members with no phone numbers are probably accounts that have gotten reset
+            members_to_discard.append(m)
 
     diff = calculate_diff(actual_members_by_phone, wanted_members)
 
-    for member in diff.invites:
-        if member.phone in pending_invites:
-            logger.info(f"accessy sync skipping, invite already pending: {member}")
+    for accessy_member in diff.invites:
+        assert accessy_member.phone is not None
+        if accessy_member.phone in pending_invites:
+            logger.info(f"accessy sync skipping, invite already pending: {accessy_member}")
             continue
-        logger.info(f"accessy sync inviting: {member}")
-        accessy_session.invite_phone_to_org_and_groups([member.phone], member.groups)
+        logger.info(f"accessy sync inviting: {accessy_member}")
+        accessy_session.invite_phone_to_org_and_groups([accessy_member.phone], accessy_member.groups)
 
     for op in diff.group_adds:
         logger.info(f"accessy sync adding to group: {op}")
-        accessy_session.add_to_group(op.member.phone, op.group)
+        accessy_session.add_to_group(op.member, op.group)
 
     for op in diff.group_removes:
         logger.info(f"accessy sync removing from group: {op}")
-        accessy_session.remove_from_group(op.member.phone, op.group)
+        accessy_session.remove_from_group(op.member, op.group)
 
-    for member in diff.org_removes:
-        logger.info(f"accessy sync removing from org: {member}")
-        accessy_session.remove_from_org(member.phone)
+    for accessy_member in diff.org_removes:
+        logger.info(f"accessy sync removing from org: {accessy_member}")
+        accessy_session.remove_from_org(accessy_member)
+
+    for accessy_member in members_to_discard:
+        logger.info(f"accessy sync removing from org: {accessy_member}, because phone number is missing")
+        accessy_session.remove_from_org(accessy_member)

--- a/api/src/systest/api/accessy_sync_test.py
+++ b/api/src/systest/api/accessy_sync_test.py
@@ -46,46 +46,85 @@ class Test(ApiTest):
             phone=random_phone_number(),
             labaccess_agreement_at=date.today(),
         )
-        self.db.create_span(startdate=self.date(-1), enddate=self.date(0), type=Span.LABACCESS)
+        self.db.create_span(
+            startdate=self.date(-1), enddate=self.date(0), type=Span.LABACCESS, member=included_because_labaccess_span
+        )
 
         included_because_special_span = self.db.create_member(
             phone=random_phone_number(),
             labaccess_agreement_at=date.today(),
         )
-        self.db.create_span(startdate=self.date(0), enddate=self.date(1), type=Span.SPECIAL_LABACESS)
+        self.db.create_span(
+            startdate=self.date(0),
+            enddate=self.date(1),
+            type=Span.SPECIAL_LABACESS,
+            member=included_because_special_span,
+        )
 
         included_because_both_kinds_of_spans = self.db.create_member(
             phone=random_phone_number(),
             labaccess_agreement_at=date.today(),
         )
-        self.db.create_span(startdate=self.date(0), enddate=self.date(0), type=Span.LABACCESS)
-        self.db.create_span(startdate=self.date(0), enddate=self.date(0), type=Span.SPECIAL_LABACESS)
+        self.db.create_span(
+            startdate=self.date(0),
+            enddate=self.date(0),
+            type=Span.LABACCESS,
+            member=included_because_both_kinds_of_spans,
+        )
+        self.db.create_span(
+            startdate=self.date(0),
+            enddate=self.date(0),
+            type=Span.SPECIAL_LABACESS,
+            member=included_because_both_kinds_of_spans,
+        )
 
         not_included_because_spans_outside_today = self.db.create_member(
             phone=random_phone_number(),
             labaccess_agreement_at=date.today(),
         )
-        self.db.create_span(startdate=self.date(-1), enddate=self.date(-1), type=Span.LABACCESS)
-        self.db.create_span(startdate=self.date(1), enddate=self.date(1), type=Span.LABACCESS)
+        self.db.create_span(
+            startdate=self.date(-1),
+            enddate=self.date(-1),
+            type=Span.LABACCESS,
+            member=not_included_because_spans_outside_today,
+        )
+        self.db.create_span(
+            startdate=self.date(1),
+            enddate=self.date(1),
+            type=Span.LABACCESS,
+            member=not_included_because_spans_outside_today,
+        )
 
-        not_included_because_labaccess_agreement_not_signed = self.db.create_member(
+        included_even_if_labaccess_agreement_not_signed = self.db.create_member(
             phone=random_phone_number(),
             labaccess_agreement_at=None,
         )
-        self.db.create_span(startdate=self.date(0), enddate=self.date(0), type=Span.LABACCESS)
+        self.db.create_span(
+            startdate=self.date(0),
+            enddate=self.date(0),
+            type=Span.LABACCESS,
+            member=included_even_if_labaccess_agreement_not_signed,
+        )
 
         not_included_because_no_phone_number = self.db.create_member(
             phone=None,
             labaccess_agreement_at=date.today(),
         )
-        self.db.create_span(startdate=self.date(0), enddate=self.date(0), type=Span.LABACCESS)
+        self.db.create_span(
+            startdate=self.date(0),
+            enddate=self.date(0),
+            type=Span.LABACCESS,
+            member=not_included_because_no_phone_number,
+        )
 
         not_included_because_deleted = self.db.create_member(
             phone=random_phone_number(),
             labaccess_agreement_at=date.today(),
             deleted_at=self.datetime(),
         )
-        self.db.create_span(startdate=self.date(0), enddate=self.date(0), type=Span.LABACCESS)
+        self.db.create_span(
+            startdate=self.date(0), enddate=self.date(0), type=Span.LABACCESS, member=not_included_because_deleted
+        )
 
         wanted = get_wanted_access(self.date())
 
@@ -93,22 +132,26 @@ class Test(ApiTest):
 
         self.assertIn(included_because_special_span.member_id, wanted_ids)
         self.assertIn(included_because_special_span.phone, wanted)
+        assert included_because_special_span.phone is not None
         self.assertIn(ACCESSY_SPECIAL_LABACCESS_GROUP, wanted[included_because_special_span.phone].groups)
 
         self.assertIn(included_because_labaccess_span.member_id, wanted_ids)
         self.assertIn(included_because_labaccess_span.phone, wanted)
+        assert included_because_labaccess_span.phone is not None
         self.assertIn(ACCESSY_LABACCESS_GROUP, wanted[included_because_labaccess_span.phone].groups)
 
         self.assertIn(included_because_both_kinds_of_spans.member_id, wanted_ids)
         self.assertIn(included_because_both_kinds_of_spans.phone, wanted)
+
+        assert included_because_both_kinds_of_spans.phone is not None
         self.assertIn(ACCESSY_LABACCESS_GROUP, wanted[included_because_both_kinds_of_spans.phone].groups)
         self.assertIn(ACCESSY_SPECIAL_LABACCESS_GROUP, wanted[included_because_both_kinds_of_spans.phone].groups)
 
         self.assertNotIn(not_included_because_spans_outside_today.member_id, wanted_ids)
         self.assertNotIn(not_included_because_spans_outside_today.phone, wanted)
 
-        self.assertNotIn(not_included_because_labaccess_agreement_not_signed.member_id, wanted_ids)
-        self.assertNotIn(not_included_because_labaccess_agreement_not_signed.phone, wanted)
+        self.assertIn(included_even_if_labaccess_agreement_not_signed.member_id, wanted_ids)
+        self.assertIn(included_even_if_labaccess_agreement_not_signed.phone, wanted)
 
         self.assertNotIn(not_included_because_no_phone_number.member_id, wanted_ids)
         self.assertNotIn(not_included_because_no_phone_number.phone, wanted)


### PR DESCRIPTION
- Reduced the number of calls we make to the AccessyAPI during syncs.
- Re-use our existing code for getting membership summaries, instead of doing custom database calls.
- Use the syncing code for when updating a single member as well, to ensure there are no differences in behaviour.
- Handle accessy users with no phone number (msisdn). I think these are accounts that have been reset.
- Members will now get access, if they have the appropriate spans, even if the labaccess agreement has not been signed. This makes accessy match how it looks in the rest of the UI. Note that spans are typically not created until the agreement has been signed. So this doesn't cause any practical changes in behaviour.
- Updated method signatures for better clarity and maintainability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to add members to groups using member objects.
	- Enhanced functionality for retrieving and syncing member access based on optional member IDs.

- **Bug Fixes**
	- Improved error handling and logging for specific status codes.

- **Documentation**
	- Added comments to clarify logic regarding membership access.

- **Refactor**
	- Simplified method signatures to accept member objects instead of phone numbers.
	- Streamlined the control flow in access-related functions.

- **Tests**
	- Updated tests to reflect changes in member handling and assertions related to lab access agreements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->