### PR TITLE
Fix sending email exception

### DIFF
--- a/admin/src/Messages/MessageAdd.js
+++ b/admin/src/Messages/MessageAdd.js
@@ -5,7 +5,7 @@ import Message from "../Models/Message";
 import { notifySuccess } from "../message";
 
 function MessageAdd(props) {
-    const { router } = props;
+    const { history } = props;
 
     // Create a new Message instance
     const message = useMemo(() => new Message(), []);
@@ -13,7 +13,7 @@ function MessageAdd(props) {
     // Handler for saving the message
     const onSend = () => {
         message.save().then(() => {
-            router.push("/messages");
+            history.push("/messages");
             notifySuccess("Ditt meddelande har skickats");
         });
     };


### PR DESCRIPTION
The exception was caused due to wrong import from react-router. 

Fixes #566 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated navigation prop naming from `router` to `history` in the message creation component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->