### PR TITLE
admin: Add created at to group list view

### DIFF
--- a/admin/src/Membership/GroupList.jsx
+++ b/admin/src/Membership/GroupList.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import Collection from "../Models/Collection";
 import CollectionTable from "../Components/CollectionTable";
-import Group from "../Models/Group";
+import Date from "../Components/DateShow";
 import SearchBox from "../Components/SearchBox";
+import Collection from "../Models/Collection";
 import CollectionNavigation from "../Models/CollectionNavigation";
+import Group from "../Models/Group";
 
 const Row = (props) => {
     const { item, deleteItem } = props;
@@ -18,6 +19,9 @@ const Row = (props) => {
                 <Link to={"/membership/groups/" + item.id}>{item.name}</Link>
             </td>
             <td>{item.num_members}</td>
+            <td>
+                <Date date={item.created_at} />
+            </td>
             <td>
                 <a onClick={() => deleteItem(item)} className="removebutton">
                     <i className="uk-icon-trash" />
@@ -44,6 +48,7 @@ class GroupList extends CollectionNavigation {
             { title: "Titel", sort: "title" },
             { title: "Namn", sort: "name" },
             { title: "Antal medlemmar" },
+            { title: "Skapad", sort: "created_at" },
             { title: "" },
         ];
 


### PR DESCRIPTION
Adds the `created_at` to the view of Groups in admin. 

There was also request to show `deleted_at`, but as far as I could tell the deleted groups are not shown in the list, so I didn't add that. If I'm missing something, or if there is anything more that should go into this PR, let me know.

Fixes #521 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added creation date column to group list
	- Implemented date display for each group's creation timestamp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->