### PR TITLE
Don't show 0s when manually creating a new member

### DIFF
--- a/admin/src/Components/MemberForm.js
+++ b/admin/src/Components/MemberForm.js
@@ -96,7 +96,9 @@ const MemberForm = ({ member, onSave, onDelete }) => {
                     </div>
                 </fieldset>
 
-                {member.id && (
+                {!member.id ? (
+                    ""
+                ) : (
                     <fieldset data-uk-margin>
                         <legend>
                             <i className="uk-icon-tag" /> Metadata
@@ -127,7 +129,9 @@ const MemberForm = ({ member, onSave, onDelete }) => {
                 )}
 
                 <div className="uk-form-row">
-                    {member.id && (
+                    {!member.id ? (
+                        ""
+                    ) : (
                         <a
                             className="uk-button uk-button-danger uk-float-left"
                             onClick={onDelete}


### PR DESCRIPTION
The member.id is 0 when the member does not yet exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved form rendering logic to hide metadata and delete button when no member ID is present
	- Refined component display conditions for better user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->