### PR TITLE
Fix boxterminator crash on exit

### DIFF
--- a/admin/src/boxTerminator/QrCodeScanner.tsx
+++ b/admin/src/boxTerminator/QrCodeScanner.tsx
@@ -1,5 +1,5 @@
-import React, { FC, useEffect } from "react";
 import { Html5Qrcode, Html5QrcodeSupportedFormats } from "html5-qrcode";
+import React, { FC, useEffect } from "react";
 
 type QrCodeScannerProps = {
     onSuccess: (qrCodeMessage: string) => void;
@@ -44,7 +44,13 @@ const QrCodeScanner: FC<QrCodeScannerProps> = ({ filterScan, onSuccess }) => {
         );
 
         return () => {
-            scanner.clear();
+            if (scanner.isScanning) {
+                scanner.stop().then(() => {
+                    scanner.clear();
+                });
+            } else {
+                scanner.clear();
+            }
         };
     }, []);
 


### PR DESCRIPTION
Fix #437 
On close the scanner gets cleared, but this can only be done if the scanner is stopped. So now it checks if the scanner is running and stops it before clearing on exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved QR code scanner cleanup logic to ensure proper resource management during component unmounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->