### PR TITLE
Fix tests

### DIFF
--- a/api/src/shop/test/subscriptions_test.py
+++ b/api/src/shop/test/subscriptions_test.py
@@ -559,7 +559,7 @@ class SubscriptionTestWithStripe(FlaskTestBase):
         Checks that a lab subscription is started with a binding period
         """
         binding_period = self.access_subscription_product.smallest_multiple
-        (now, clock, member) = self.setup_single_member()
+        (now, clock, member) = self.setup_single_member(start_time=datetime(2024, 10, 1, tzinfo=timezone.utc))
 
         stripe_subscriptions.start_subscription(
             member,


### PR DESCRIPTION
Pin the time so we get deterministic tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test case for subscription binding period to use a fixed start time.
	- Ensures consistent test behavior by setting a predetermined start date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->