### PR TITLE
Remove redundant withRouter usages

### DIFF
--- a/admin/src/Components/GroupForm.js
+++ b/admin/src/Components/GroupForm.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { withRouter } from "react-router";
 import DateTimeInput from "./DateTimeInput";
 import TextInput from "./TextInput";
 import Textarea from "./Textarea";
@@ -74,4 +73,4 @@ const GroupForm = ({ group, onSave, onDelete }) => {
     );
 };
 
-export default withRouter(GroupForm);
+export default GroupForm;

--- a/admin/src/Components/KeyHandoutForm.jsx
+++ b/admin/src/Components/KeyHandoutForm.jsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { renderToString } from "react-dom/server";
-import { Prompt, withRouter } from "react-router";
+import { Prompt } from "react-router";
 import { get, post } from "../gateway";
 import { notifySuccess } from "../message";
 import Collection from "../Models/Collection";
@@ -85,19 +85,17 @@ function DateView(props) {
 
 function KeyHandoutForm(props) {
     const { member } = props;
-    const [can_save_member, setCanSaveMember] = React.useState(false);
-    const [pending_labaccess_days, setPendingLabaccessDays] =
-        React.useState("?");
-    const [labaccess_enddate, setLabaccessEnddate] = React.useState("");
-    const [membership_enddate, setMembershipEnddate] = React.useState("");
-    const [special_enddate, setSpecialEnddate] = React.useState("");
-    const [accessy_in_org, setAccessyInOrg] = React.useState(false);
-    const [accessy_groups, setAccessyGroups] = React.useState([]);
-    const [accessy_pending_invites, setAccessyPendingInvites] =
-        React.useState(0);
+    const [can_save_member, setCanSaveMember] = useState(false);
+    const [pending_labaccess_days, setPendingLabaccessDays] = useState("?");
+    const [labaccess_enddate, setLabaccessEnddate] = useState("");
+    const [membership_enddate, setMembershipEnddate] = useState("");
+    const [special_enddate, setSpecialEnddate] = useState("");
+    const [accessy_in_org, setAccessyInOrg] = useState(false);
+    const [accessy_groups, setAccessyGroups] = useState([]);
+    const [accessy_pending_invites, setAccessyPendingInvites] = useState(0);
 
-    const unsubscribe = React.useRef([]);
-    const spanCollection = React.useMemo(
+    const unsubscribe = useRef([]);
+    const spanCollection = useMemo(
         () =>
             new Collection({
                 type: Span,
@@ -139,7 +137,7 @@ function KeyHandoutForm(props) {
         });
     };
 
-    React.useEffect(() => {
+    useEffect(() => {
         unsubscribe.current.push(
             member.subscribe(() => setCanSaveMember(member.canSave())),
         );
@@ -449,4 +447,4 @@ function KeyHandoutForm(props) {
     );
 }
 
-export default withRouter(KeyHandoutForm);
+export default KeyHandoutForm;

--- a/admin/src/Components/MemberForm.js
+++ b/admin/src/Components/MemberForm.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { withRouter } from "react-router";
 import CountryDropdown from "./CountryDropdown";
 import DateTimeShow from "./DateTimeShow";
 import TextInput from "./TextInput";
@@ -152,4 +151,4 @@ const MemberForm = ({ member, onSave, onDelete }) => {
     );
 };
 
-export default withRouter(MemberForm);
+export default MemberForm;

--- a/admin/src/Membership/GroupBox.jsx
+++ b/admin/src/Membership/GroupBox.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { withRouter } from "react-router";
 import GroupContext from "../Contexts/GroupContext";
 import Group from "../Models/Group";
 import { NavItem } from "../nav";
@@ -47,4 +46,4 @@ function GroupBox(props) {
     );
 }
 
-export default withRouter(GroupBox);
+export default GroupBox;

--- a/admin/src/Membership/GroupBox.jsx
+++ b/admin/src/Membership/GroupBox.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
 import GroupContext from "../Contexts/GroupContext";
 import Group from "../Models/Group";
 import { NavItem } from "../nav";
 
 function GroupBox(props) {
-    const { group_id } = props.match.params;
+    const { group_id } = useParams();
     const group = useMemo(() => Group.get(group_id), [group_id]);
     const [title, setTitle] = useState("");
 

--- a/admin/src/Membership/GroupBoxEditInfo.jsx
+++ b/admin/src/Membership/GroupBoxEditInfo.jsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { withRouter } from "react-router";
 import GroupForm from "../Components/GroupForm";
 import GroupContext from "../Contexts/GroupContext";
 import { confirmModal } from "../message";
@@ -30,4 +29,4 @@ const GroupBoxEditInfo = (props) => {
     );
 };
 
-export default withRouter(GroupBoxEditInfo);
+export default GroupBoxEditInfo;

--- a/admin/src/Membership/GroupBoxEditInfo.jsx
+++ b/admin/src/Membership/GroupBoxEditInfo.jsx
@@ -1,10 +1,11 @@
 import React, { useContext } from "react";
+import { useHistory } from "react-router-dom";
 import GroupForm from "../Components/GroupForm";
 import GroupContext from "../Contexts/GroupContext";
 import { confirmModal } from "../message";
 
-const GroupBoxEditInfo = (props) => {
-    const { router } = props;
+const GroupBoxEditInfo = () => {
+    const history = useHistory();
     const group = useContext(GroupContext);
 
     if (!group) {
@@ -20,7 +21,7 @@ const GroupBoxEditInfo = (props) => {
                     confirmModal(group.deleteConfirmMessage())
                         .then(() => group.del())
                         .then(() => {
-                            router.push("/membership/groups/");
+                            history.push("/membership/groups/");
                         })
                         .catch(() => null);
                 }}

--- a/admin/src/Membership/GroupBoxPermissions.jsx
+++ b/admin/src/Membership/GroupBoxPermissions.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { useParams } from "react-router-dom";
 import Select from "react-select";
 import * as _ from "underscore";
 import CollectionTable from "../Components/CollectionTable";
@@ -6,7 +7,8 @@ import Collection from "../Models/Collection";
 import Permission from "../Models/Permission";
 import { get } from "../gateway";
 
-const GroupBoxPermissions = (props) => {
+const GroupBoxPermissions = () => {
+    const { group_id } = useParams();
     const [showOptions, setShowOptions] = useState([]);
     const [selectedOption, setSelectedOption] = useState(null);
     const [options, setOptions] = useState([]);
@@ -14,7 +16,7 @@ const GroupBoxPermissions = (props) => {
     const collectionRef = useRef(
         new Collection({
             type: Permission,
-            url: `/membership/group/${props.match.params.group_id}/permissions`,
+            url: `/membership/group/${group_id}/permissions`,
             idListName: "permissions",
             pageSize: 0,
         }),

--- a/admin/src/Membership/KeyHandout.jsx
+++ b/admin/src/Membership/KeyHandout.jsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { withRouter } from "react-router";
 import KeyHandoutForm from "../Components/KeyHandoutForm";
 import { MemberContext } from "./MemberBox";
 
@@ -12,4 +11,4 @@ const KeyHandout = () => {
     );
 };
 
-export default withRouter(KeyHandout);
+export default KeyHandout;

--- a/admin/src/Membership/MemberBox.jsx
+++ b/admin/src/Membership/MemberBox.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React, { createContext, useEffect, useRef, useState } from "react";
-import { useParams, withRouter } from "react-router";
+import { useParams } from "react-router";
 import Member from "../Models/Member";
 import { NavItem } from "../nav";
 
@@ -78,4 +78,4 @@ MemberBox.propTypes = {
     children: PropTypes.node,
 };
 
-export default withRouter(MemberBox);
+export default MemberBox;

--- a/admin/src/Membership/MemberBoxKeys.js
+++ b/admin/src/Membership/MemberBoxKeys.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import CollectionTable from "../Components/CollectionTable";
 import DateTimeShow from "../Components/DateTimeShow";
 import TextInput from "../Components/TextInput";
@@ -37,8 +37,8 @@ const Row = (collection) => (props) => {
     );
 };
 
-function MemberBoxKeys(props) {
-    const member_id = props.match.params.member_id;
+function MemberBoxKeys() {
+    const { member_id } = useParams();
 
     const collectionRef = useRef(
         new Collection({

--- a/admin/src/Membership/MemberBoxMemberData.jsx
+++ b/admin/src/Membership/MemberBoxMemberData.jsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { withRouter } from "react-router";
 import { browserHistory } from "../browser_history";
 import MemberForm from "../Components/MemberForm";
 import { confirmModal } from "../message";
@@ -28,4 +27,4 @@ function MemberBoxMemberData() {
     );
 }
 
-export default withRouter(MemberBoxMemberData);
+export default MemberBoxMemberData;

--- a/admin/src/Membership/MemberBoxNewMessage.js
+++ b/admin/src/Membership/MemberBoxNewMessage.js
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { withRouter } from "react-router";
 import { useParams } from "react-router-dom";
 import MessageForm from "../Components/MessageForm";
 import Message from "../Models/Message";
@@ -32,4 +31,4 @@ const MemberBoxMessages = () => {
     );
 };
 
-export default withRouter(MemberBoxMessages);
+export default MemberBoxMessages;

--- a/admin/src/Membership/MemberBoxOrders.js
+++ b/admin/src/Membership/MemberBoxOrders.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import CollectionTable from "../Components/CollectionTable";
 import DateTimeShow from "../Components/DateTimeShow";
 import Collection from "../Models/Collection";
@@ -20,8 +20,8 @@ const Row = ({ item }) => {
     );
 };
 
-function MemberBoxOrders(props) {
-    const member_id = props.match.params.member_id;
+function MemberBoxOrders() {
+    const { member_id } = useParams();
     const collection = new Collection({
         type: Order,
         url: `/webshop/member/${member_id}/transactions`,

--- a/admin/src/Membership/MemberBoxPermissions.js
+++ b/admin/src/Membership/MemberBoxPermissions.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { useParams } from "react-router-dom";
 import CollectionTable from "../Components/CollectionTable";
 import Collection from "../Models/Collection";
 import Permission from "../Models/Permission";
@@ -9,8 +10,8 @@ const Row = ({ item }) => (
     </tr>
 );
 
-function MemberBoxPermissions(props) {
-    const member_id = props.match.params.member_id;
+function MemberBoxPermissions() {
+    const { member_id } = useParams();
     const collection = new Collection({
         type: Permission,
         url: `/membership/member/${member_id}/permissions`,

--- a/admin/src/Membership/MemberBoxSpans.jsx
+++ b/admin/src/Membership/MemberBoxSpans.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import "react-day-picker/lib/style.css";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import CollectionTable from "../Components/CollectionTable";
 import DateShow from "../Components/DateShow";
 import DateTimeShow from "../Components/DateTimeShow";
@@ -11,8 +11,8 @@ import { get } from "../gateway";
 import { confirmModal } from "../message";
 import MembershipPeriodsInput from "./MembershipPeriodsInput";
 
-function MemberBoxSpans(props) {
-    const memberId = props.match.params.member_id;
+function MemberBoxSpans() {
+    const { member_id } = useParams();
 
     const [, setItems] = useState([]);
     const [pendingLabaccessDays, setPendingLabaccessDays] = useState("?");
@@ -20,14 +20,14 @@ function MemberBoxSpans(props) {
     const collectionRef = useRef(
         new Collection({
             type: Span,
-            url: `/membership/member/${memberId}/spans`,
+            url: `/membership/member/${member_id}/spans`,
             pageSize: 0,
             includeDeleted: true,
         }),
     );
 
     useEffect(() => {
-        get({ url: `/membership/member/${memberId}/pending_actions` }).then(
+        get({ url: `/membership/member/${member_id}/pending_actions` }).then(
             (r) => {
                 const sum_pending_labaccess_days = r.data.reduce(
                     (acc, value) => {
@@ -40,7 +40,7 @@ function MemberBoxSpans(props) {
                 setPendingLabaccessDays(sum_pending_labaccess_days);
             },
         );
-    }, [memberId]);
+    }, [member_id]);
 
     useEffect(() => {
         const unsubscribe = collectionRef.current.subscribe(({ items }) => {
@@ -69,7 +69,7 @@ function MemberBoxSpans(props) {
             <hr />
             <MembershipPeriodsInput
                 spans={collectionRef.current}
-                member_id={memberId}
+                member_id={member_id}
             />
             <h2>Spans</h2>
             <hr />

--- a/admin/src/Membership/SpanShow.jsx
+++ b/admin/src/Membership/SpanShow.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
 import * as _ from "underscore";
 import Span from "../Models/Span";
 
-function SpanShow(props) {
-    const { span_id } = props.match.params;
+function SpanShow() {
+    const { span_id } = useParams();
     const spanInstance = useMemo(() => Span.get(span_id), [span_id]);
     const [data, setData] = useState({});
 

--- a/admin/src/Messages/MessageAdd.js
+++ b/admin/src/Messages/MessageAdd.js
@@ -1,5 +1,4 @@
 import React, { useMemo } from "react";
-import { withRouter } from "react-router";
 import MessageForm from "../Components/MessageForm";
 import Message from "../Models/Message";
 import { notifySuccess } from "../message";
@@ -28,4 +27,4 @@ function MessageAdd(props) {
     );
 }
 
-export default withRouter(MessageAdd);
+export default MessageAdd;

--- a/admin/src/Messages/MessageShow.js
+++ b/admin/src/Messages/MessageShow.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
 import DateTimeShow from "../Components/DateTimeShow";
 import Message from "../Models/Message";
 
-function MessageShow(props) {
-    const { id } = props.match.params;
+function MessageShow() {
+    const { id } = useParams();
     const messageInstance = useMemo(() => Message.get(id), [id]);
 
     const [message, setMessage] = useState(() => {

--- a/admin/src/Messages/MessageShow.js
+++ b/admin/src/Messages/MessageShow.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { withRouter } from "react-router";
 import DateTimeShow from "../Components/DateTimeShow";
 import Message from "../Models/Message";
 
@@ -98,4 +97,4 @@ function MessageShow(props) {
     );
 }
 
-export default withRouter(MessageShow);
+export default MessageShow;

--- a/admin/src/Quiz/QuizAdd.tsx
+++ b/admin/src/Quiz/QuizAdd.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { withRouter } from "react-router";
 import Quiz from "../Models/Quiz";
 import { browserHistory } from "../browser_history";
 import QuizEditForm from "./QuizEditForm";

--- a/admin/src/Quiz/QuizEditForm.tsx
+++ b/admin/src/Quiz/QuizEditForm.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { withRouter } from "react-router";
-import Quiz from "../Models/Quiz";
 import Textarea from "../Components/Textarea";
 import TextInput from "../Components/TextInput";
+import Quiz from "../Models/Quiz";
 
 interface Props {
     quiz: Quiz | null;

--- a/admin/src/nav.jsx
+++ b/admin/src/nav.jsx
@@ -1,10 +1,11 @@
 import React from "react";
-import * as _ from "underscore";
-import { withRouter, matchPath } from "react-router";
+import { matchPath, useLocation } from "react-router";
 import { Link, NavLink } from "react-router-dom";
+import * as _ from "underscore";
 
-export const NavItem = withRouter((props) => {
-    const { location, icon, to } = props;
+export const NavItem = (props) => {
+    const { icon, to } = props;
+    const location = useLocation();
 
     return (
         <li className={location.pathname.indexOf(to) >= 0 ? "uk-active" : ""}>
@@ -19,7 +20,7 @@ export const NavItem = withRouter((props) => {
             </NavLink>
         </li>
     );
-});
+};
 
 export const Nav = ({ nav: { brand, items } }) => (
     <nav className="uk-navbar">
@@ -38,7 +39,8 @@ export const Nav = ({ nav: { brand, items } }) => (
     </nav>
 );
 
-export const SideNav = withRouter(({ nav, location }) => {
+export const SideNav = ({ nav }) => {
+    const location = useLocation();
     let activeItem = _.find(
         nav.items,
         (i) => matchPath(location.pathname, i.target) !== null,
@@ -87,4 +89,4 @@ export const SideNav = withRouter(({ nav, location }) => {
             </ul>
         </div>
     );
-});
+};


### PR DESCRIPTION
They should use the appropriate hooks when needed instead.
Also, `withRouter` is deprecated in React Router Dom v6, so removing this means less problems in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed `withRouter` from multiple components across the admin section.
	- Updated component exports to use direct export instead of HOC wrapping.
	- Simplified routing prop management in various components by utilizing hooks.

- **Chores**
	- Cleaned up unused router-related imports.
	- Modernized component export patterns.

These changes enhance code clarity and maintainability, aligning with modern React practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->