### PR TITLE
Run frontend tests separately from the build step

### DIFF
--- a/.github/workflows/makeradmin.yml
+++ b/.github/workflows/makeradmin.yml
@@ -32,6 +32,19 @@ jobs:
       - name: Run tests
         run: make test
 
+  admin-frontend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set time zone
+        run: sudo timedatectl set-timezone Europe/Stockholm
+      - name: Install packages
+        run: npm --prefix admin ci
+      - name: Run tests
+        run: npm --prefix admin run test
+      - name: Lint
+        run: npm --prefix admin run eslint
+
   stripe-tests:
     runs-on: ubuntu-latest
     concurrency: stripe

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -15,10 +15,6 @@ RUN npm ci
 COPY ./src/ /work/src
 COPY ./jestSetup.js /work/
 
-RUN npm run eslint
-
-RUN npm run test
-
 RUN npm run build
 RUN echo tsc --version
 


### PR DESCRIPTION
Previously, the backend tests would not run in CI if there was for example an eslint error. But now we can still build, and run the other tests, so we also get better coverage.