### PR TITLE
Fix: Member without phone number could not login

### DIFF
--- a/api/src/multiaccessy/accessy.py
+++ b/api/src/multiaccessy/accessy.py
@@ -477,7 +477,15 @@ class AccessySession:
 
     def _get_users_org(self) -> list[dict]:
         """Get all user ID:s"""
-        return self._get_json_paginated(f"/asset/admin/organization/{self.organization_id()}/user")
+
+        def is_application(user: dict) -> bool:
+            return user.get("msisdn", None) is None
+
+        return [
+            v
+            for v in self._get_json_paginated(f"/asset/admin/organization/{self.organization_id()}/user")
+            if not is_application(v)
+        ]
         # {"items":[{"id":<uuid>,"msisdn":"+46...","firstName":str,"lastName":str}, ...],"totalItems":6,"pageSize":25,"pageNumber":0,"totalPages":1}
 
     def _get_users_in_access_group(self, access_group_id: UUID) -> list[dict]:


### PR DESCRIPTION
Apparently, applications are also returned when listing the users from the Accessy API. But they don't have the "msisdn", so we can filter on that.