### PR TITLE
Fix error in 0b2834e9bb7344b1516eabd05314fc9c2357290c

### DIFF
--- a/api/src/shop/models.py
+++ b/api/src/shop/models.py
@@ -137,7 +137,7 @@ class Transaction(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
 
     member: Mapped[Member] = relationship(Member)
-    stripe_pending: Mapped[Optional["StripePending"]] = relationship("StripePending")
+    stripe_pending: Mapped[list["StripePending"]] = relationship("StripePending")
 
     def __repr__(self) -> str:
         return f"Transaction(id={self.id}, amount={self.amount}, status={self.status}, created_at={self.created_at})"

--- a/api/src/shop/test/transactions_test.py
+++ b/api/src/shop/test/transactions_test.py
@@ -1,0 +1,29 @@
+from decimal import Decimal
+
+import membership.models
+import shop.models
+from service.db import db_session
+from shop.transactions import get_source_transaction
+from test_aid.test_base import FlaskTestBase
+
+
+class ShopDataTest(FlaskTestBase):
+    models = [membership.models, shop.models]
+
+    def test_finds_transaction_for_stripe_pending(self) -> None:
+        member = self.db.create_member()
+        transaction = self.db.create_transaction(
+            member_id=member.member_id,
+            amount=Decimal("50"),
+            status=shop.models.Transaction.PENDING,
+        )
+        pending = shop.models.StripePending(
+            transaction_id=transaction.id,
+            stripe_token="stripe_token",
+        )
+        db_session.add(pending)
+        db_session.commit()
+
+        found_transaction = get_source_transaction("stripe_token")
+        self.assertIsNotNone(found_transaction)
+        self.assertEqual(transaction.id, found_transaction.id)


### PR DESCRIPTION
Restores it as a collection, instead of a scalar.

Fixes the error:

```
  File "/work/src/shop/transactions.py", line 87, in get_source_transaction
    .filter(Transaction.stripe_pending.any(StripePending.stripe_token == source_id))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
sqlalchemy.exc.InvalidRequestError: 'any()' not implemented for scalar attributes. Use has().
```