### PR TITLE
Improve Accessy sync

### DIFF
--- a/api/src/accessy_syncer.py
+++ b/api/src/accessy_syncer.py
@@ -16,18 +16,16 @@ COMMAND_SHIP = "ship"
 COMMAND_SYNC = "sync"
 
 
-def scheduled_ship_and_sync():
+def scheduled_ship():
+    logger.info("shipping orders")
     try:
-        logger.info("shipping orders")
         ship_orders()
-        logger.info("syncing accessy")
-        sync()
         db_session.commit()
-        logger.info("committing changes to db")
     except Exception as e:
         logger.exception(f"failed to ship orders: {e}")
     finally:
         db_session.remove()
+    logger.info("finished shipping orders")
 
 
 def scheduled_sync():
@@ -35,21 +33,16 @@ def scheduled_sync():
     try:
         sync()
         db_session.commit()
-        logger.info("finished syncing accessy")
     except Exception as e:
         logger.exception(f"failed to sync with accessy: {e}")
     finally:
         db_session.remove()
-
-
-friday = 4
+    logger.info("finished syncing accessy")
 
 
 def daily_job():
-    if datetime.today().weekday() is friday:
-        scheduled_ship_and_sync()
-    else:
-        scheduled_sync()
+    scheduled_ship()
+    scheduled_sync()
 
 
 def main():


### PR DESCRIPTION
Fixes bug where members were kicked out during the nightly sync if one of the threads crashed due to Accessy throttling the requests too much:

```python
Exception in thread Thread-8 (worker):                                                                                                                                                                                                     
Traceback (most recent call last):                                                                                                                                                                                                           
File "/usr/local/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.11/threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "/work/src/multiaccessy/accessy.py", line 552, in worker
    fill_user_details(member)
  File "/work/src/multiaccessy/accessy.py", line 522, in fill_user_details
    data = self.get_user_details(user.user_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/src/multiaccessy/accessy.py", line 456, in get_user_details
    json = self._get_user_details(user_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/src/multiaccessy/accessy.py", line 470, in _get_user_details
    return self._get(f"/org/admin/user/{user_id}", err_msg="Getting user details")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/src/multiaccessy/accessy.py", line 397, in _get
    return request("get", path, token=self.session_token, err_msg=err_msg)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/src/multiaccessy/accessy.py", line 83, in request
    raise AccessyError("too many requests")
multiaccessy.accessy.AccessyError: too many requests
```