### PR TITLE
Fix crash when searching on accounting pages

### DIFF
--- a/admin/src/Models/CollectionNavigation.ts
+++ b/admin/src/Models/CollectionNavigation.ts
@@ -49,7 +49,7 @@ export default class CollectionNavigation<
             this.params.set("search", this.state.search);
         }
 
-        if (this.state.page === 1) {
+        if (!this.state.page || this.state.page === 1) {
             this.params.delete("page");
         } else {
             this.params.set("page", this.state.page.toString());

--- a/admin/src/Sales/AccountingAccount.js
+++ b/admin/src/Sales/AccountingAccount.js
@@ -87,7 +87,10 @@ class AccountingAccount extends CollectionNavigation {
                 </div>
 
                 <div className="uk-margin-top">
-                    <SearchBox handleChange={this.onSearch} />
+                    <SearchBox
+                        handleChange={this.onSearch}
+                        value={this.state.search}
+                    />
                     <CollectionTable
                         className="uk-margin-top"
                         collection={this.collection}

--- a/admin/src/Sales/AccountingCostCenter.js
+++ b/admin/src/Sales/AccountingCostCenter.js
@@ -90,7 +90,10 @@ class AccountingCostCenter extends CollectionNavigation {
                 </div>
 
                 <div className="uk-margin-top">
-                    <SearchBox handleChange={this.onSearch} />
+                    <SearchBox
+                        handleChange={this.onSearch}
+                        value={this.state.search}
+                    />
                     <CollectionTable
                         className="uk-margin-top"
                         collection={this.collection}

--- a/admin/src/Sales/AccountingProduct.js
+++ b/admin/src/Sales/AccountingProduct.js
@@ -455,7 +455,10 @@ class AccountingProduct extends CollectionNavigation {
                 </form>
 
                 <div className="uk-margin-top">
-                    <SearchBox handleChange={this.onSearch} />
+                    <SearchBox
+                        handleChange={this.onSearch}
+                        value={this.state.search}
+                    />
 
                     <CollectionTable
                         id="product_table"


### PR DESCRIPTION
This is an ugly fix just to remove the symptom. We will anyway rewrite the CollectionNavigation class etc. into functional components, so I didn't feel that there's a need to make a better solution at the moment.

Fixes #635