### PR TITLE
readable docker image dependency versions

### DIFF
--- a/admin/DevServerDockerfile
+++ b/admin/DevServerDockerfile
@@ -1,4 +1,5 @@
-FROM node:19-alpine@sha256:8ec543d4795e2e85af924a24f8acb039792ae9fe8a42ad5b4bf4c277ab34b62e
+# syntax=docker/dockerfile:1.11
+FROM node:19.9.0-alpine3.18@sha256:8ec543d4795e2e85af924a24f8acb039792ae9fe8a42ad5b4bf4c277ab34b62e
 
 RUN apk add --no-cache tzdata
 ENV TZ Europe/Stockholm

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:19-alpine@sha256:8ec543d4795e2e85af924a24f8acb039792ae9fe8a42ad5b4bf4c277ab34b62e
+# syntax=docker/dockerfile:1.11
+FROM node:19.9.0-alpine3.18@sha256:8ec543d4795e2e85af924a24f8acb039792ae9fe8a42ad5b4bf4c277ab34b62e
 
 RUN apk add --no-cache tzdata
 ENV TZ=Europe/Stockholm
@@ -18,7 +19,7 @@ COPY ./jestSetup.js /work/
 RUN npm run build
 RUN echo tsc --version
 
-FROM nginx:alpine@sha256:74175cf34632e88c6cfe206897cbfe2d2fecf9bf033c40e7f9775a3689e8adc7
+FROM nginx:1.27.2-alpine3.20@sha256:74175cf34632e88c6cfe206897cbfe2d2fecf9bf033c40e7f9775a3689e8adc7
 
 # Configuration file for nginx
 COPY ./docker/nginx_default_host /etc/nginx/conf.d/default.conf

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-alpine@sha256:5d769f990397afbb2aca24b0655e404c0f2806d268f454b052e81e39d87abf42
+# syntax=docker/dockerfile:1.11
+FROM python:3.11.5-alpine3.18.3@sha256:5d769f990397afbb2aca24b0655e404c0f2806d268f454b052e81e39d87abf42
 
 RUN apk update \
     && apk add \

--- a/api/TestDockerfile
+++ b/api/TestDockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-alpine@sha256:004b4029670f2964bb102d076571c9d750c2a43b51c13c768e443c95a71aa9f3
+# syntax=docker/dockerfile:1.11
+FROM python:3.11.10-alpine3.20.3@sha256:004b4029670f2964bb102d076571c9d750c2a43b51c13c768e443c95a71aa9f3
 
 RUN apk update \
     && apk add \

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-alpine@sha256:5d769f990397afbb2aca24b0655e404c0f2806d268f454b052e81e39d87abf42
+# syntax=docker/dockerfile:1.11
+FROM python:3.11.5-alpine3.18.3@sha256:5d769f990397afbb2aca24b0655e404c0f2806d268f454b052e81e39d87abf42
 
 RUN mkdir /work
 

--- a/public/Dockerfile
+++ b/public/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-alpine@sha256:5d769f990397afbb2aca24b0655e404c0f2806d268f454b052e81e39d87abf42
+# syntax=docker/dockerfile:1.11
+FROM python:3.11.5-alpine3.18.3@sha256:5d769f990397afbb2aca24b0655e404c0f2806d268f454b052e81e39d87abf42
 
 RUN apk update \
 	&& apk add \


### PR DESCRIPTION
Since we've already locked down the exact images we want with `@sha256:...` we might as well include the full, human readable, version of the name :slightly_smiling_face: 

That e.g. makes the difference between `api/TestDockerfile`
```Dockerfile
FROM python:3.11.10-alpine3.20.3@sha256:00b4...
```
and our other python images
```Dockerfile
FROM python:3.11.5-alpine3.18.3@sha256:5d76...
```
easier to spot and reason about than by just looking at the hashes